### PR TITLE
Fix dependencies for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
   "torchaudio==2.7.0",
   "transformers==4.57.1",
   "uvicorn>=0.29.0",
+  "WeTextProcessing>=1.0.4.1",
+  "soundfile>=0.13.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ sentencepiece>=0.1.99
 torch==2.7.0
 torchaudio==2.7.0
 transformers==4.57.1
-sentencepiece
 uvicorn>=0.29.0
 WeTextProcessing>=1.0.4.1
-soundfile
+soundfile>=0.13.1


### PR DESCRIPTION
Synchronizes dependencies in requirements.txt and pyproject.toml

Installing with `uv sync` now just works.

Fixes #1