### PR TITLE
feat: ONNX export + CPU inference for edge deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,11 @@ weights/tts/*.bin
 weights/tts/tokenizer.model
 generated_audio/*
 .app_prompt_uploads/*
+
+# ONNX deployment: local model checkpoints, exported bundle, runtime outputs
+MOSS-TTS-Nano-100M/
+MOSS-Audio-Tokenizer-Nano/
+onnx_export/
+output/
+codex/
+.codex

--- a/README.md
+++ b/README.md
@@ -41,21 +41,27 @@ MOSS-TTS-Nano is an open-source **multilingual tiny speech generation model** fr
 
 ## Contents
 
-- [News](#news)
-- [Demo](#demo)
-- [Introduction](#introduction)
-  - [Main Features](#main-features)
-- [Supported Languages](#supported-languages)
-- [Quickstart](#quickstart)
-  - [Environment Setup](#environment-setup)
-  - [Voice Clone with `infer.py`](#voice-clone-with-inferpy)
-  - [Local Web Demo with `app.py`](#local-web-demo-with-apppy)
-  - [CLI Command: `moss-tts-nano generate`](#cli-command-moss-tts-nano-generate)
-  - [CLI Command: `moss-tts-nano serve`](#cli-command-moss-tts-nano-serve)
-- [MOSS-Audio-Tokenizer-Nano](#moss-audio-tokenizer-nano)
-- [License](#license)
-- [Citation](#citation)
-- [Star History](#star-history)
+- [MOSS-TTS-Nano](#moss-tts-nano)
+  - [News](#news)
+  - [Demo](#demo)
+  - [Contents](#contents)
+  - [Introduction](#introduction)
+    - [Main Features](#main-features)
+  - [Supported Languages](#supported-languages)
+  - [Quickstart](#quickstart)
+    - [Environment Setup](#environment-setup)
+      - [Using Conda](#using-conda)
+    - [Voice Clone with `infer.py`](#voice-clone-with-inferpy)
+    - [Local Web Demo with `app.py`](#local-web-demo-with-apppy)
+    - [CLI Command: `moss-tts-nano generate`](#cli-command-moss-tts-nano-generate)
+    - [CLI Command: `moss-tts-nano serve`](#cli-command-moss-tts-nano-serve)
+    - [ONNX deployment](#onnx-deployment)
+  - [MOSS-Audio-Tokenizer-Nano](#moss-audio-tokenizer-nano)
+    - [Introduction](#introduction-1)
+    - [Model Weights](#model-weights)
+  - [License](#license)
+  - [Citation](#citation)
+  - [Star History](#star-history)
 
 ## Introduction
 
@@ -171,6 +177,20 @@ moss-tts-nano serve
 ```
 
 This command forwards to `app.py`, keeps the model loaded in memory, and serves the local browser demo plus HTTP generation endpoints.
+
+### ONNX deployment
+
+For deployment in environments without PyTorch / Transformers (mobile, browser via `onnxruntime-web`, micro-services, embedded apps), the repository ships an end-to-end ONNX bundle:
+
+```bash
+# Export the bundle (FP32 + INT8 dynamic quantization)
+python export_onnx.py
+
+# Run inference (CPU INT8, ~80 ms first-chunk latency on a 4-core laptop)
+python onnx_infer.py --text "你好世界。" --output output/hello.wav
+```
+
+The bundle is ~165 MB INT8 in total and supports both standard generation and voice cloning. See [README_ONNX.md](README_ONNX.md) for the full design notes, performance numbers, and architectural background.
 
 ## MOSS-Audio-Tokenizer-Nano
 

--- a/README_ONNX.md
+++ b/README_ONNX.md
@@ -1,0 +1,250 @@
+# MOSS-TTS-Nano · ONNX Bundle
+
+[English](README_ONNX.md) | [简体中文](README_ONNX_zh.md)
+
+This document describes the ONNX export and inference pipeline added to
+MOSS-TTS-Nano. The goal is to make the model deployable as a fully self-
+contained ONNX bundle that runs on CPU via ONNX Runtime without any
+PyTorch / Transformers dependency at inference time.
+
+## Table of contents
+
+- [MOSS-TTS-Nano · ONNX Bundle](#moss-tts-nano--onnx-bundle)
+  - [Table of contents](#table-of-contents)
+  - [Why ONNX](#why-onnx)
+  - [What is exported](#what-is-exported)
+  - [Export](#export)
+  - [Inference](#inference)
+  - [Voice cloning](#voice-cloning)
+  - [Performance](#performance)
+  - [Architecture notes](#architecture-notes)
+  - [Repository layout](#repository-layout)
+  - [Limitations](#limitations)
+
+## Why ONNX
+
+The reference Python entry points (`infer.py`, `app.py`, the
+`moss-tts-nano` CLI) require PyTorch + Transformers + a HuggingFace cache.
+That is fine for research and the local web demo, but it makes embedding
+the model into other runtimes (mobile, browser via onnxruntime-web,
+desktop apps, microservices) noticeably heavier.
+
+The bundle produced by `export_onnx.py` lets you ship MOSS-TTS-Nano as
+**six small ONNX graphs (~165 MB INT8 in total)** plus the SentencePiece
+tokenizer and a tiny `config.json`. Inference is implemented in
+`onnx_infer.py` using only `onnxruntime`, `numpy`, `soundfile`, and
+`sentencepiece`.
+
+The model is **autoregressive by nature**, so the inference loop is also
+chunk-by-chunk: each generated code frame is decoded into audio
+immediately, and the first chunk is available before the full sentence
+finishes generating.
+
+## What is exported
+
+A successful run of `python export_onnx.py` writes the following files
+into `onnx_export/` (sizes from a sample run, FP32 / INT8):
+
+| File | Role | FP32 | INT8 |
+|---|---|---:|---:|
+| `audio_encoder.onnx` | Audio tokenizer encoder; encodes the prompt waveform for voice cloning. | 45.4 MB | 15.7 MB |
+| `global_transformer.onnx` | 12-layer GPT2 + token embeddings. Returns the last-token hidden state with explicit KV cache I/O. | 441.1 MB | 111.0 MB |
+| `local_decoder_text.onnx` | 1-layer local GPT2 head producing the candidate text-/EOS-token logits. | 28.4 MB | 7.1 MB |
+| `local_decoder_audio.onnx` | 1-layer local GPT2 head producing the 16 audio codebook tokens. Hybrid input mode (external embed / internal lookup). | 78.7 MB | 19.7 MB |
+| `audio_decoder.onnx` | Audio tokenizer decoder, one frame per call, with explicit KV-cache I/O. | 44.4 MB | 11.5 MB |
+| `audio_decoder_state_spec.json` | KV-cache layout descriptor consumed by the runtime. | 6 KB | – |
+| `tokenizer.model` | SentencePiece tokenizer copied as-is. | 0.5 MB | – |
+| `config.json` | Inference parameters (nq, vocab size, special token ids, sampling defaults, sample rate). | <1 KB | – |
+| `manifest.json` | Bundle metadata: schema, quantization settings, file sizes. | <1 KB | – |
+
+**Totals (sample run): ~640 MB FP32 / ~165 MB INT8 for the five graphs.**
+
+INT8 weights are produced via `onnxruntime.quantization.quantize_dynamic`
+with `weight_type=QInt8`, `per_channel=False`, `reduce_range=False`. These
+settings were validated as the smallest *and* fastest configuration on
+these graphs across multiple grids; the activations stay in FP32.
+
+## Export
+
+```bash
+python export_onnx.py \
+    --tts-checkpoint ./MOSS-TTS-Nano-100M \
+    --audio-tokenizer-checkpoint ./MOSS-Audio-Tokenizer-Nano \
+    --output-dir ./onnx_export
+```
+
+CLI flags:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--tts-checkpoint` | `./MOSS-TTS-Nano-100M` | Local path or HF repo for the LM checkpoint. |
+| `--audio-tokenizer-checkpoint` | `./MOSS-Audio-Tokenizer-Nano` | Local path or HF repo for the audio tokenizer. |
+| `--output-dir` | `./onnx_export` | Where to write the bundle. |
+| `--nq` | `16` | Number of audio codebooks (must match the model). |
+| `--device` | `cpu` | Export device. CPU is fine; GPU is not required. |
+| `--skip-verify` | – | Skip the ORT-vs-PyTorch numerical sanity check. |
+| `--skip-quantize` | – | Skip INT8 dynamic quantization. |
+
+Pipeline:
+
+1. Loads `MOSS-TTS-Nano-100M` (causal LM) and `MOSS-Audio-Tokenizer-Nano`
+   (codec) via `from_pretrained` with `attn_implementation="sdpa"`.
+2. Traces five PyTorch wrappers to ONNX (`audio_encoder`,
+   `global_transformer`, `local_decoder_text`, `local_decoder_audio`,
+   `audio_decoder`).
+3. Runs ORT-side graph optimizations: GPT2-specific operator fusion via
+   `onnxruntime.transformers.optimizer` for the global transformer, and
+   `ORT_ENABLE_EXTENDED` for the rest.
+4. Verifies each graph against the original PyTorch wrapper on a few
+   shapes (`max_diff` should stay below `1e-3`).
+5. Runs INT8 dynamic quantization on every model.
+6. Copies `tokenizer.model`, writes `config.json` and `manifest.json`.
+
+The export takes ~5 minutes on a modern laptop CPU. No GPU required.
+
+## Inference
+
+```bash
+python onnx_infer.py \
+    --onnx-dir onnx_export \
+    --precision int8 \
+    --text "你好，这是一段使用 ONNX 推理生成的语音。" \
+    --output output/hello.wav
+```
+
+CLI flags:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--onnx-dir` | `onnx_export` | Path to the bundle. |
+| `--precision` | `int8` | One of `auto`, `int8`, `fp32`. `int8` falls back to FP32 for any model whose `*_int8.onnx` is missing. |
+| `--text` / `--text-file` | (required, mutually exclusive) | Input text or UTF-8 file. |
+| `--output` | (required) | Destination wav path. |
+| `--threads` | `2` | ORT intra-op thread count. |
+| `--prompt-audio-path` | – | Reference audio for voice cloning. |
+| `--max-frames` | `300` | Max audio frames to generate before forcing EOS. |
+
+What runs at inference time:
+
+1. Text is normalized via `text_normalization_pipeline.prepare_tts_request_texts`
+   and tokenized with SentencePiece.
+2. A prompt is built and fed into `global_transformer` token-by-token with
+   incremental KV cache (no recomputation).
+3. Each step runs `local_decoder_text` to sample the next text/EOS token,
+   then `local_decoder_audio` 16 times to sample one full audio frame.
+4. The frame is immediately handed to `audio_decoder.step()`, which keeps
+   its own KV cache and yields one waveform chunk in O(1).
+5. The chunks are concatenated and written as a single wav file.
+
+Sampling defaults are read from `config.json` and can be overridden via
+`OnnxTTSEngine.generate(...)` keyword arguments.
+
+## Voice cloning
+
+Pass a reference wav with `--prompt-audio-path`:
+
+```bash
+python onnx_infer.py \
+    --onnx-dir onnx_export \
+    --precision int8 \
+    --prompt-audio-path assets/audio/zh_1.wav \
+    --text "复刻一下这段声音的音色。" \
+    --output output/clone.wav
+```
+
+The prompt audio is read with `soundfile`, resampled to 48 kHz / stereo
+with `resampy`, and encoded by `audio_encoder.onnx` into 16-codebook
+tokens. Those tokens become the audio prefix that conditions the LM.
+
+If `--prompt-audio-path` is supplied, mode automatically switches from
+`continuation` to `voice_clone`.
+
+## Performance
+
+Numbers from a 4-core CPU laptop, INT8, single thread for inter-op,
+2 threads for intra-op:
+
+| Mode | Text | Audio length | First chunk | RTF |
+|---|---|---:|---:|---:|
+| continuation | "你好，这是一个端到端测试。" (13 chars) | 2.80 s | **80 ms** | 0.33 |
+| voice_clone | "克隆模式测试。" + `assets/audio/zh_1.wav` | 1.52 s | 1023 ms | 0.95 |
+
+Notes:
+
+- **First-chunk latency in continuation mode is ~50–90 ms** on CPU INT8:
+  one full AR step (global + local-text + 16× local-audio) plus one
+  audio-decoder call.
+- **Voice clone first-chunk latency is dominated by prompt encoding.**
+  About 92 % of the ~1 s spent on the first chunk in clone mode is
+  prompt I/O + resampling + `audio_encoder.run`. Once the first chunk is
+  out, subsequent chunks have the same per-step cost as continuation.
+- **Steady-state RTF is well below 1.0** in both modes (faster than
+  realtime), so streaming consumers will never starve after warmup.
+
+## Architecture notes
+
+A few design decisions that explain why the bundle looks the way it does:
+
+- **Wrapper-per-graph instead of one monolithic export.** The model has
+  three logical pieces (text/audio token mixing global LM, two local
+  heads, audio codec). Exporting them separately keeps each ONNX graph
+  small enough for INT8 dynamic quantization to be applied with simple
+  per-tensor settings, and lets `onnxruntime.transformers.optimizer`
+  apply GPT2-specific fusions to the global transformer only.
+- **Explicit KV-cache I/O for both the LM and the audio decoder.** The
+  cache state is exposed as ONNX inputs/outputs, with shape information
+  stored in `audio_decoder_state_spec.json`. This is what enables true
+  per-frame O(1) decoding (no recompute over the prefix) while keeping
+  the export traceable in plain `torch.onnx.export`.
+- **`local_decoder_audio` uses hybrid input mode.** A single graph
+  handles both the "first audio channel" path (consume external
+  hidden-state from the global transformer) and the "next 15 channels"
+  path (look up the previously emitted audio token internally). This
+  avoids exporting two near-duplicate graphs.
+- **Per-tensor INT8 with `DefaultTensorType=FLOAT`.** `per_channel=True`
+  produced larger files with no measurable speedup on these graphs;
+  `reduce_range=True` made some kernels fall back to a slower path on
+  CPU EP. The chosen setting was validated as the smallest-and-fastest
+  point in a small grid search.
+
+## Repository layout
+
+The ONNX work adds three Python files at the repository root:
+
+```
+MOSS-TTS-Nano/
+├── export_onnx.py        # PyTorch -> ONNX bundle (this PR)
+├── onnx_infer.py         # CLI + OnnxTTSEngine (this PR)
+├── onnx_tts_utils.py     # SentencePiece + sampling utilities (this PR)
+├── onnx_export/          # Bundle output directory (gitignored)
+│   ├── audio_encoder[_int8].onnx
+│   ├── global_transformer[_int8].onnx
+│   ├── local_decoder_text[_int8].onnx
+│   ├── local_decoder_audio[_int8].onnx
+│   ├── audio_decoder[_int8].onnx
+│   ├── audio_decoder_state_spec.json
+│   ├── tokenizer.model
+│   ├── config.json
+│   └── manifest.json
+└── ... (existing PyTorch entrypoints unchanged)
+```
+
+The PR does **not** touch any existing file: `infer.py`, `app.py`,
+`moss_tts_nano_runtime.py`, the `moss_tts_nano/` package, the text
+normalization scripts, the model checkpoints, or the assets folder all
+behave exactly as before.
+
+## Limitations
+
+- **CPU only, ONNX Runtime CPU EP.** The bundle works on any platform
+  ORT supports, but no GPU-specific optimizations have been done. CUDA
+  EP and `onnxruntime-web` should both work but are not tested here.
+- **Batch size 1.** Both the LM step and the audio decoder are exported
+  with `batch=1` to keep the KV-cache layout simple. Batched inference
+  would need a re-export.
+- **Maximum sequence length.** The exported global transformer uses
+  fully dynamic `seq_len` axes, but the local decoder fixes
+  `seq_len = NQ + 1 = 17` (one frame). Long-form generation is handled
+  by the streaming loop, not by changing this shape.
+- **No CoreML / ORT-mobile packaging.** The graphs are vanilla ONNX
+  opset 17. Conversion to other runtimes is left to downstream users.

--- a/README_ONNX_zh.md
+++ b/README_ONNX_zh.md
@@ -1,0 +1,233 @@
+# MOSS-TTS-Nano · ONNX 部署套件
+
+[English](README_ONNX.md) | [简体中文](README_ONNX_zh.md)
+
+本文档说明 MOSS-TTS-Nano 的 ONNX 导出与推理流程，目标是把模型打包成一个
+**自包含的 ONNX bundle**，仅依赖 ONNX Runtime，在 CPU 上即可推理，运行
+时不再需要 PyTorch / Transformers。
+
+## 目录
+
+- [MOSS-TTS-Nano · ONNX 部署套件](#moss-tts-nano--onnx-部署套件)
+  - [目录](#目录)
+  - [为什么要做 ONNX](#为什么要做-onnx)
+  - [导出了什么](#导出了什么)
+  - [导出](#导出)
+  - [推理](#推理)
+  - [声音克隆](#声音克隆)
+  - [性能](#性能)
+  - [架构说明](#架构说明)
+  - [仓库布局](#仓库布局)
+  - [已知限制](#已知限制)
+
+## 为什么要做 ONNX
+
+仓库现有的 Python 入口（`infer.py`、`app.py`、`moss-tts-nano` CLI）依赖
+PyTorch + Transformers + HuggingFace 缓存。这套依赖对研究和本地 demo 没
+有问题，但要把模型嵌入到其他运行时（移动端、`onnxruntime-web` 浏览器、
+桌面应用、微服务）就略显沉重。
+
+`export_onnx.py` 产出的 bundle 把 MOSS-TTS-Nano 拆成 **6 张小型 ONNX 图
+（INT8 总计约 165 MB）**，外加 SentencePiece tokenizer 与一份精简
+`config.json`。`onnx_infer.py` 给出对应的推理实现，运行时只用
+`onnxruntime`、`numpy`、`soundfile`、`sentencepiece`。
+
+模型本身就是**自回归**的，因此推理循环也是逐帧的：每生成一帧 audio code
+就立即解码出一段音频，**第一段音频在整句生成完之前就能拿到**。
+
+## 导出了什么
+
+成功执行 `python export_onnx.py` 后会在 `onnx_export/` 下生成（大小取自
+一次样例运行，FP32 / INT8）：
+
+| 文件 | 作用 | FP32 | INT8 |
+|---|---|---:|---:|
+| `audio_encoder.onnx` | 音频 tokenizer 编码器；用于声音克隆时把 prompt 音频编码为 token。 | 45.4 MB | 15.7 MB |
+| `global_transformer.onnx` | 12 层 GPT2 + token embeddings；返回最后一个 token 的 hidden state，KV cache 显式作为 I/O。 | 441.1 MB | 111.0 MB |
+| `local_decoder_text.onnx` | 1 层 local GPT2，输出候选文本/EOS token 的 logits。 | 28.4 MB | 7.1 MB |
+| `local_decoder_audio.onnx` | 1 层 local GPT2，输出 16 个 audio codebook token。混合输入模式（外部 embed / 内部 lookup）。 | 78.7 MB | 19.7 MB |
+| `audio_decoder.onnx` | 音频 tokenizer 解码器，**单帧调用**，KV cache 显式 I/O。 | 44.4 MB | 11.5 MB |
+| `audio_decoder_state_spec.json` | KV cache 布局描述，运行时按它装配输入。 | 6 KB | – |
+| `tokenizer.model` | SentencePiece tokenizer 原样复制。 | 0.5 MB | – |
+| `config.json` | 推理参数：nq、词表、特殊 token id、采样默认值、采样率等。 | <1 KB | – |
+| `manifest.json` | bundle 元信息：schema 版本、量化设置、文件清单与大小。 | <1 KB | – |
+
+**总计（样例运行）：5 张图 FP32 ~640 MB / INT8 ~165 MB。**
+
+INT8 权重通过 `onnxruntime.quantization.quantize_dynamic` 生成，参数：
+`weight_type=QInt8`、`per_channel=False`、`reduce_range=False`。这组配置
+在多次网格对比中被验证为**体积最小且推理最快**的选择，激活值保持 FP32。
+
+## 导出
+
+```bash
+python export_onnx.py \
+    --tts-checkpoint ./MOSS-TTS-Nano-100M \
+    --audio-tokenizer-checkpoint ./MOSS-Audio-Tokenizer-Nano \
+    --output-dir ./onnx_export
+```
+
+可选参数：
+
+| 参数 | 默认值 | 说明 |
+|---|---|---|
+| `--tts-checkpoint` | `./MOSS-TTS-Nano-100M` | LM checkpoint 的本地路径或 HF repo。 |
+| `--audio-tokenizer-checkpoint` | `./MOSS-Audio-Tokenizer-Nano` | 音频 tokenizer 的本地路径或 HF repo。 |
+| `--output-dir` | `./onnx_export` | bundle 输出目录。 |
+| `--nq` | `16` | 音频 codebook 数（必须与模型一致）。 |
+| `--device` | `cpu` | 导出设备，CPU 即可。 |
+| `--skip-verify` | – | 跳过 ORT vs PyTorch 的数值一致性校验。 |
+| `--skip-quantize` | – | 跳过 INT8 动态量化。 |
+
+执行流程：
+
+1. 用 `from_pretrained(..., attn_implementation="sdpa")` 加载
+   `MOSS-TTS-Nano-100M`（LM）和 `MOSS-Audio-Tokenizer-Nano`（音频 codec）。
+2. 把 5 个 PyTorch wrapper 通过 `torch.onnx.export` 导出为 ONNX
+   （`audio_encoder`、`global_transformer`、`local_decoder_text`、
+   `local_decoder_audio`、`audio_decoder`）。
+3. 跑 ORT 端的图优化：global transformer 用
+   `onnxruntime.transformers.optimizer` 做 GPT2 专项 fuse，其余模型用
+   `ORT_ENABLE_EXTENDED`。
+4. 在若干典型 shape 上做 ORT vs PyTorch 一致性校验
+   （`max_diff` 应低于 `1e-3`）。
+5. 对全部模型做 INT8 动态量化。
+6. 拷贝 `tokenizer.model`，写出 `config.json` 与 `manifest.json`。
+
+
+## 推理
+
+```bash
+python onnx_infer.py \
+    --onnx-dir onnx_export \
+    --precision int8 \
+    --text "你好，这是一段使用 ONNX 推理生成的语音。" \
+    --output output/hello.wav
+```
+
+可选参数：
+
+| 参数 | 默认值 | 说明 |
+|---|---|---|
+| `--onnx-dir` | `onnx_export` | bundle 路径。 |
+| `--precision` | `int8` | `auto` / `int8` / `fp32`。`int8` 在缺失对应 `*_int8.onnx` 时会自动回退到 FP32。 |
+| `--text` / `--text-file` | （二选一必填） | 输入文本或 UTF-8 文本文件。 |
+| `--output` | （必填） | 输出 wav 路径。 |
+| `--threads` | `2` | ORT intra-op 线程数。 |
+| `--prompt-audio-path` | – | 声音克隆参考音频。 |
+| `--max-frames` | `300` | 最多生成多少帧前强制 EOS。 |
+
+推理时的具体步骤：
+
+1. 文本经 `text_normalization_pipeline.prepare_tts_request_texts`
+   归一化，再用 SentencePiece 切分为 token。
+2. 构造 prompt，逐 token 喂入 `global_transformer`，KV cache 增量推进
+   （前缀不重算）。
+3. 每一步先用 `local_decoder_text` 采样下一个文本/EOS token，再用
+   `local_decoder_audio` 串行 16 次采样出一帧完整的 audio code。
+4. 这一帧立即送入 `audio_decoder.step()`，解码器自己维护 KV cache，
+   每次返回一段 O(1) 的 waveform chunk。
+5. 把所有 chunk 拼起来写成一个 wav 文件。
+
+采样默认值从 `config.json` 读取，可以通过
+`OnnxTTSEngine.generate(...)` 的关键字参数覆盖。
+
+## 声音克隆
+
+加上 `--prompt-audio-path` 即可：
+
+```bash
+python onnx_infer.py \
+    --onnx-dir onnx_export \
+    --precision int8 \
+    --prompt-audio-path assets/audio/zh_1.wav \
+    --text "复刻一下这段声音的音色。" \
+    --output output/clone.wav
+```
+
+参考音频用 `soundfile` 读入，用 `resampy` 重采样到 48 kHz 立体声，再交
+给 `audio_encoder.onnx` 编码为 16 个 codebook 的 token，作为音频前缀
+喂给 LM 进行条件生成。
+
+只要带了 `--prompt-audio-path`，模式会自动从 `continuation` 切到
+`voice_clone`。
+
+## 性能
+
+下面是 4 核 CPU 笔记本上的实测，INT8、`inter_op_num_threads=1`、
+`intra_op_num_threads=2`：
+
+| 模式 | 输入文本 | 音频时长 | 首帧延迟 | RTF |
+|---|---|---:|---:|---:|
+| continuation | "你好，这是一个端到端测试。"（13 字） | 2.80 s | **80 ms** | 0.33 |
+| voice_clone | "克隆模式测试。" + `assets/audio/zh_1.wav` | 1.52 s | 1023 ms | 0.95 |
+
+说明：
+
+- **continuation 模式首帧延迟约 50–90 ms**：CPU INT8 上一次完整 AR step
+  （global + local-text + 16 次 local-audio）加一次 audio decoder 调用。
+- **voice clone 的首帧延迟瓶颈在 prompt 编码**。约 92 % 的时间花在读
+  音频 + 重采样 + `audio_encoder.run` 上。第一帧出来之后，后续每帧的成
+  本与 continuation 完全相同。
+- **稳态 RTF 都低于 1.0**（快于实时），流式消费者在预热后不会出现
+  "断流"。
+
+## 架构说明
+
+几个关键设计选择：
+
+- **拆成多个 wrapper 而不是单一 monolithic 导出。** 模型本身就由三块逻
+  辑组成（文本/音频混合的 global LM、两个 local 头、音频 codec），分别
+  导出可以让每张图都小到能用最朴素的 per-tensor INT8，并且让
+  `onnxruntime.transformers.optimizer` 的 GPT2 专项 fuse 只作用在
+  global transformer 上。
+- **LM 与 audio decoder 都把 KV cache 暴露成 ONNX I/O。** cache 形状描
+  述存在 `audio_decoder_state_spec.json` 里。这样既能做到逐帧 O(1) 解
+  码（不重算前缀），又保留了 `torch.onnx.export` 的可追踪性。
+- **`local_decoder_audio` 用混合输入模式。** 同一张图同时处理"第 0 个
+  音频通道：消费 global transformer 的外部 hidden state"和"第 1–15 个
+  通道：内部 lookup 上一个音频 token"两种路径，避免导出两张近乎重复的
+  图。
+- **per-tensor INT8 + `DefaultTensorType=FLOAT`。** `per_channel=True`
+  在这些图上反而更大且没有可测速度收益；`reduce_range=True` 会让某些
+  kernel 走 CPU EP 上较慢的路径。当前配置是小型网格对比里"体积+速度同
+  时最优"的点。
+
+## 仓库布局
+
+ONNX 相关工作在仓库根目录新增三个 Python 文件：
+
+```
+MOSS-TTS-Nano/
+├── export_onnx.py        # PyTorch -> ONNX bundle（本 PR）
+├── onnx_infer.py         # CLI + OnnxTTSEngine（本 PR）
+├── onnx_tts_utils.py     # SentencePiece + 采样工具（本 PR）
+├── onnx_export/          # bundle 输出目录（已加入 .gitignore）
+│   ├── audio_encoder[_int8].onnx
+│   ├── global_transformer[_int8].onnx
+│   ├── local_decoder_text[_int8].onnx
+│   ├── local_decoder_audio[_int8].onnx
+│   ├── audio_decoder[_int8].onnx
+│   ├── audio_decoder_state_spec.json
+│   ├── tokenizer.model
+│   ├── config.json
+│   └── manifest.json
+└── ...（其它 PyTorch 入口与原仓库完全一致）
+```
+
+本 PR **不修改任何已有文件**：`infer.py`、`app.py`、
+`moss_tts_nano_runtime.py`、`moss_tts_nano/` 包、文本归一化脚本、模型
+权重、`assets/` 等等都保持原状。
+
+## 已知限制
+
+- **仅 CPU、仅 ONNX Runtime CPU EP**。bundle 在任何 ORT 支持的平台上
+  都能运行，但没有做 GPU 专项优化。CUDA EP 和 `onnxruntime-web` 在原
+  理上可以工作但未在本仓库验证。
+- **batch_size = 1**。LM step 和 audio decoder 都按 `batch=1` 导出，
+  以保持 KV cache 布局简单。批量推理需要重新导出。
+- **最大序列长度**。global transformer 的 `seq_len` 轴是动态的，但
+  local decoder 固定 `seq_len = NQ + 1 = 17`（一帧）。长文本通过外层
+  循环拼接生成，而不是通过改这个形状。
+- **没有打包到 CoreML / ORT-mobile**。导出的是标准 ONNX opset 17，转
+  换到其它运行时需要使用方自行处理。

--- a/README_zh.md
+++ b/README_zh.md
@@ -38,21 +38,27 @@ MOSS-TTS-Nano 是来自 [MOSI.AI](https://mosi.cn/#hero) 和 [OpenMOSS 团队](h
 
 ## 目录
 
-- [新闻](#新闻)
-- [演示](#演示)
-- [介绍](#介绍)
-  - [主要特性](#主要特性)
-- [支持的语言](#支持的语言)
-- [快速开始](#快速开始)
-  - [环境配置](#环境配置)
-  - [使用 `infer.py` 进行语音克隆](#使用-inferpy-进行语音克隆)
-  - [使用 `app.py` 启动本地-web-演示](#使用-apppy-启动本地-web-演示)
-  - [CLI 命令：`moss-tts-nano generate`](#cli-命令-moss-tts-nano-generate)
-  - [CLI 命令：`moss-tts-nano serve`](#cli-命令-moss-tts-nano-serve)
-- [MOSS-Audio-Tokenizer-Nano](#moss-audio-tokenizer-nano)
-- [许可证](#许可证)
-- [引用](#引用)
-- [Star 历史](#star-历史)
+- [MOSS-TTS-Nano](#moss-tts-nano)
+  - [新闻](#新闻)
+  - [演示](#演示)
+  - [目录](#目录)
+  - [介绍](#介绍)
+    - [主要特性](#主要特性)
+  - [支持的语言](#支持的语言)
+  - [快速开始](#快速开始)
+    - [环境配置](#环境配置)
+      - [使用 Conda](#使用-conda)
+    - [使用 `infer.py` 进行语音克隆](#使用-inferpy-进行语音克隆)
+    - [使用 `app.py` 启动本地 Web 演示](#使用-apppy-启动本地-web-演示)
+    - [CLI 命令：`moss-tts-nano generate`](#cli-命令moss-tts-nano-generate)
+    - [CLI 命令：`moss-tts-nano serve`](#cli-命令moss-tts-nano-serve)
+    - [ONNX 部署](#onnx-部署)
+  - [MOSS-Audio-Tokenizer-Nano](#moss-audio-tokenizer-nano)
+    - [介绍](#介绍-1)
+    - [模型权重](#模型权重)
+  - [许可证](#许可证)
+  - [引用](#引用)
+  - [Star 历史](#star-历史)
 
 ## 介绍
 
@@ -166,6 +172,20 @@ moss-tts-nano serve
 ```
 
 此命令转发到 `app.py`，将模型保持在内存中加载，并为本地浏览器演示和 HTTP 生成端点提供服务。
+
+### ONNX 部署
+
+如果需要在没有 PyTorch / Transformers 的环境（移动端、`onnxruntime-web` 浏览器、微服务、嵌入式应用）部署模型，仓库提供了一套端到端的 ONNX bundle：
+
+```bash
+# 导出 bundle（FP32 + INT8 动态量化）
+python export_onnx.py
+
+# 运行推理（CPU INT8，4 核笔记本首帧约 80 ms）
+python onnx_infer.py --text "你好世界。" --output output/hello.wav
+```
+
+INT8 总体积约 165 MB，同时支持标准生成与声音克隆。完整的设计说明、性能数据与架构背景请参考 [README_ONNX_zh.md](README_ONNX_zh.md)。
 
 ## MOSS-Audio-Tokenizer-Nano
 

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,0 +1,1217 @@
+"""Export MOSS-TTS-Nano to an ONNX bundle.
+
+Produces ``onnx_export/`` containing:
+
+    audio_encoder.onnx              Audio tokenizer encoder (used for the
+                                    voice-clone prompt path)
+    audio_decoder.onnx              Audio tokenizer decoder, exported with
+                                    explicit KV-cache I/O (one frame per call)
+    audio_decoder_state_spec.json   KV-cache layout descriptor
+    global_transformer.onnx         12-layer GPT2 + token embeddings
+                                    (last-token hidden state)
+    local_decoder_text.onnx         1-layer local GPT2 + 2-row candidate wte
+    local_decoder_audio.onnx        1-layer local GPT2 + embedded audio heads
+                                    (hybrid input mode)
+    tokenizer.model                 SentencePiece tokenizer
+    config.json                     Inference parameters
+    manifest.json                   Bundle metadata + file sizes
+
+INT8 versions (``*_int8.onnx``) are produced via dynamic quantization with
+codex-validated optimal settings (per_channel=False, reduce_range=False).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import AutoModel, AutoModelForCausalLM
+
+logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=logging.INFO)
+log = logging.getLogger(__name__)
+
+NQ = 16
+LOCAL_MAX_LEN = NQ + 1  # 17: fixed sequence length for local decoder ONNX
+NUM_LAYERS = 12
+NUM_HEADS = 12
+HEAD_DIM = 64
+HIDDEN = 768
+OPSET = 17
+
+# Audio tokenizer's `create_sin_embedding` is needed by the audio decoder
+# wrapper. Make the tokenizer's source dir importable.
+_AUDIO_TOKENIZER_ROOT = Path(__file__).resolve().parent / "MOSS-Audio-Tokenizer-Nano"
+if _AUDIO_TOKENIZER_ROOT.is_dir() and str(_AUDIO_TOKENIZER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_AUDIO_TOKENIZER_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Wrapper 1: Audio Encoder
+# ---------------------------------------------------------------------------
+class AudioEncoderWrapper(nn.Module):
+    """Wraps Audio Tokenizer encode path: encoder stack + RLFQ quantizer."""
+
+    def __init__(self, audio_tokenizer):
+        super().__init__()
+        self.encoder = audio_tokenizer.encoder
+        self.quantizer = audio_tokenizer.quantizer
+        self.downsample_rate = audio_tokenizer.downsample_rate
+        self.number_channels = audio_tokenizer.number_channels
+        self.enable_channel_interleave = audio_tokenizer.enable_channel_interleave
+
+    def forward(self, waveform: torch.Tensor, input_lengths: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            waveform:      float32 [2, T] stereo 48kHz
+            input_lengths: int64 [1] — pre-computed interleaved+padded length
+                           (must be a tensor input so ONNX treats it as dynamic)
+        Returns:
+            audio_codes: int64 [16, 1, S]
+        """
+        x = waveform.unsqueeze(0)  # [1, 2, T]
+
+        pad_rem = x.shape[-1] % self.downsample_rate
+        if pad_rem != 0:
+            x = F.pad(x, (0, self.downsample_rate - pad_rem))
+
+        if self.number_channels > 1 and self.enable_channel_interleave:
+            x = x.transpose(1, 2).contiguous().view(x.shape[0], 1, -1)
+
+        h, h_len = x, input_lengths
+        for enc_module in self.encoder:
+            h, h_len = enc_module(h, h_len)
+
+        z = self.quantizer.input_proj(h).float()
+        batch_size, _, max_time = z.shape
+        mask = torch.arange(max_time, device=z.device).expand(batch_size, max_time) < h_len.unsqueeze(1)
+
+        residual = z.clone()
+        all_indices = []
+        for i, quant in enumerate(self.quantizer.quantizers):
+            if i >= self.quantizer.num_quantizers:
+                break
+            masked_residual = residual * mask.unsqueeze(1)
+            z_e = quant.in_proj(masked_residual)
+            encodings = z_e.transpose(1, 2).reshape(-1, z_e.shape[1])
+            codebook = quant.codebook.weight.float()
+            encodings = F.normalize(encodings)
+            codebook_n = F.normalize(codebook)
+            dist = (
+                encodings.pow(2).sum(1, keepdim=True)
+                - 2 * encodings @ codebook_n.t()
+                + codebook_n.pow(2).sum(1, keepdim=True).t()
+            )
+            indices = (-dist).max(1)[1]
+            indices = indices.reshape(z_e.size(0), -1)
+
+            z_q = F.embedding(indices, codebook).transpose(1, 2)
+            z_q = quant.out_proj(z_q).float()
+
+            update_mask = mask.unsqueeze(1)
+            residual = residual - z_q * update_mask
+            all_indices.append(indices)
+
+        audio_codes = torch.stack(all_indices)  # [16, 1, S]
+        return audio_codes
+
+
+# ---------------------------------------------------------------------------
+# Wrapper 2: Global Transformer (Embedding + 12-layer GPT2 w/ KV cache)
+# ---------------------------------------------------------------------------
+class GlobalTransformerWrapper(nn.Module):
+    """Embedding layer + GPT2 global transformer with explicit KV cache I/O."""
+
+    def __init__(self, tts_model, nq: int = NQ):
+        super().__init__()
+        self.transformer = tts_model.transformer
+        self.text_embedding = tts_model.transformer.wte
+        self.audio_embeddings = nn.ModuleList(
+            list(tts_model.audio_embeddings[:nq])
+        )
+        self.audio_pad_token_id = tts_model.config.audio_pad_token_id
+        self.nq = nq
+        self.n_layers = len(self.transformer.h)
+
+    def _build_inputs_embeds(self, input_ids: torch.LongTensor) -> torch.FloatTensor:
+        text_ids = input_ids[..., 0]
+        embeds = self.text_embedding(text_ids)
+        for ch, emb_layer in enumerate(self.audio_embeddings):
+            ch_ids = input_ids[..., ch + 1]
+            valid = ch_ids.ne(self.audio_pad_token_id)
+            safe = ch_ids.masked_fill(~valid, 0)
+            a_emb = emb_layer(safe)
+            embeds = embeds + a_emb * valid.unsqueeze(-1)
+        return embeds
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.LongTensor,
+        *past_kv_flat: torch.Tensor,
+    ) -> tuple:
+        """
+        Args:
+            input_ids:      [1, T, nq+1]
+            attention_mask: [1, total_T]
+            position_ids:   [1, T]
+            past_kv_flat:   2*n_layers tensors, each [1, past_T, num_heads, head_dim]
+        Returns:
+            hidden_state, present_key_0, present_value_0, ..., present_key_N, present_value_N
+        """
+        past_key_values = tuple(
+            (past_kv_flat[2 * i], past_kv_flat[2 * i + 1])
+            for i in range(self.n_layers)
+        )
+
+        inputs_embeds = self._build_inputs_embeds(input_ids)
+
+        outputs = self.transformer(
+            input_ids=None,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            use_cache=True,
+            output_attentions=False,
+            output_hidden_states=False,
+            return_dict=True,
+            cu_seqlens=None,
+            num_sequences=None,
+        )
+
+        hidden = outputs.last_hidden_state[:, -1:, :]
+        presents = outputs.past_key_values
+
+        result = [hidden]
+        for layer_kv in presents:
+            result.append(layer_kv[0])
+            result.append(layer_kv[1])
+        return tuple(result)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper 3: Local Decoder — Shared base for Text and Audio heads
+# ---------------------------------------------------------------------------
+class _LocalDecoderBase(nn.Module):
+    """Shared single-layer transformer logic for both local decoders."""
+
+    def __init__(self, tts_model):
+        super().__init__()
+        lt = tts_model.local_transformer
+        block = lt.h[0]
+        attn = block.attn
+        self.ln_1 = block.ln_1
+        self.ln_2 = block.ln_2
+        self.ln_f = lt.ln_f
+        self.c_attn = attn.c_attn
+        self.c_proj = attn.c_proj
+        self.num_heads = attn.num_heads
+        self.head_dim = attn.head_dim
+        self.hidden_size = attn.embed_dim
+        if attn.rotary_emb is not None:
+            self.register_buffer("rotary_inv_freq", attn.rotary_emb.inv_freq.clone())
+        else:
+            self.rotary_inv_freq = None
+        self.mlp_fc_in = block.mlp.fc_in
+        self.mlp_fc_out = block.mlp.fc_out
+        self.mlp_act = block.mlp.act
+
+    def _local_forward(
+        self,
+        h: torch.FloatTensor,
+        position_id: torch.LongTensor,
+        past_key: torch.FloatTensor,
+        past_value: torch.FloatTensor,
+    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
+        """Run single-layer attention + MLP, return (hidden [1,H], key, value)."""
+        H = self.hidden_size
+        normed = self.ln_1(h)
+        qkv = self.c_attn(normed)
+        q, k, v = qkv.split(H, dim=-1)
+        q = q.view(1, 1, self.num_heads, self.head_dim)
+        k = k.view(1, 1, self.num_heads, self.head_dim)
+        v = v.view(1, 1, self.num_heads, self.head_dim)
+        if self.rotary_inv_freq is not None:
+            half_dim = self.rotary_inv_freq.shape[0]
+            freqs = torch.einsum("bs,d->bsd", position_id.float(), self.rotary_inv_freq)
+            freqs_full = freqs.unsqueeze(-1).expand(-1, -1, -1, 2).reshape(1, 1, half_dim * 2)
+            cos = freqs_full.cos().unsqueeze(2).to(dtype=q.dtype)
+            sin = freqs_full.sin().unsqueeze(2).to(dtype=q.dtype)
+            even_q, odd_q = q[..., ::2], q[..., 1::2]
+            q = q * cos + torch.stack((-odd_q, even_q), dim=-1).reshape_as(q) * sin
+            even_k, odd_k = k[..., ::2], k[..., 1::2]
+            k = k * cos + torch.stack((-odd_k, even_k), dim=-1).reshape_as(k) * sin
+        k = torch.cat([past_key, k], dim=1)
+        v = torch.cat([past_value, v], dim=1)
+        q_t = q.transpose(1, 2)
+        k_t = k.transpose(1, 2)
+        v_t = v.transpose(1, 2)
+        scale = 1.0 / (self.head_dim ** 0.5)
+        scores = torch.matmul(q_t, k_t.transpose(-1, -2)) * scale
+        attn_weights = torch.softmax(scores, dim=-1)
+        attn_out = torch.matmul(attn_weights, v_t)
+        attn_out = attn_out.transpose(1, 2).reshape(1, 1, H)
+        attn_out = self.c_proj(attn_out)
+        h = h + attn_out
+        mlp_out = self.mlp_fc_in(self.ln_2(h))
+        mlp_out = self.mlp_act(mlp_out)
+        mlp_out = self.mlp_fc_out(mlp_out)
+        h = h + mlp_out
+        h = self.ln_f(h)
+        hidden = h.squeeze(1)  # [1, H]
+        return hidden, k, v
+
+
+class LocalDecoderTextWrapper(_LocalDecoderBase):
+    """1-layer local transformer for text token prediction (1x per frame).
+
+    Only embeds the 2 candidate token rows from wte (audio_slot, audio_end),
+    not the full 16384-row table. Outputs:
+      - candidate_logits [1, 2]: logits for [audio_slot, audio_end]
+      - candidate_embeds [2, H]: embeddings for both candidates (caller picks
+        one after sampling and passes it to the audio model)
+    """
+
+    def __init__(self, tts_model):
+        super().__init__(tts_model)
+        cfg = tts_model.config
+        slot_id = cfg.audio_assistant_slot_token_id
+        end_id = cfg.audio_end_token_id
+        full_wte = tts_model.transformer.wte.weight.detach()
+        self.candidate_wte = nn.Parameter(
+            full_wte[[slot_id, end_id]].clone(), requires_grad=False,
+        )  # [2, H] — row 0 = audio_slot, row 1 = audio_end
+
+    def forward(
+        self,
+        input_embed: torch.FloatTensor,   # [1, 1, H]
+        position_id: torch.LongTensor,     # [1, 1]
+        past_key: torch.FloatTensor,       # [1, past_T, num_heads, head_dim]
+        past_value: torch.FloatTensor,
+    ) -> tuple:
+        """Returns (candidate_logits [1, 2], candidate_embeds [2, H],
+                    present_key, present_value)."""
+        hidden, k, v = self._local_forward(input_embed, position_id, past_key, past_value)
+        logits = torch.mm(hidden, self.candidate_wte.t())  # [1, 2]
+        return logits, self.candidate_wte, k, v
+
+
+class LocalDecoderAudioWrapper(_LocalDecoderBase):
+    """1-layer local transformer for audio channel prediction (16x per frame).
+
+    Hybrid input resolution:
+    - use_input_embed=1: uses externally provided input_embed
+    - use_input_embed=0: performs internal Gather from audio_lm_heads
+    """
+
+    def __init__(self, tts_model, nq: int = NQ):
+        super().__init__(tts_model)
+        audio_weights = torch.stack([
+            tts_model.audio_embeddings[i].weight.detach().clone()
+            for i in range(nq)
+        ])  # [nq, audio_V, H]
+        self.audio_lm_heads = nn.Parameter(audio_weights, requires_grad=False)
+
+    def forward(
+        self,
+        input_embed: torch.FloatTensor,       # [1, 1, H] — external embed
+        position_id: torch.LongTensor,        # [1, 1]
+        past_key: torch.FloatTensor,          # [1, past_T, ...]
+        past_value: torch.FloatTensor,
+        head_id: torch.LongTensor,            # [1] — 1..16 audio channel
+        use_input_embed: torch.LongTensor,    # [1] — 1=use input_embed, 0=internal lookup
+        prev_audio_ch: torch.LongTensor,      # [1] — 0-indexed audio ch for lookup
+        prev_token_id: torch.LongTensor,      # [1] — token id for internal lookup
+    ) -> tuple:
+        """Returns (audio_logits [1, audio_V], present_key, present_value)."""
+        looked_up = self.audio_lm_heads[prev_audio_ch[0], prev_token_id[0]]
+        ext = input_embed.squeeze(0).squeeze(0)
+        h = torch.where(use_input_embed.bool(), ext, looked_up)
+        h = h.unsqueeze(0).unsqueeze(0)  # [1, 1, H]
+
+        hidden, k, v = self._local_forward(h, position_id, past_key, past_value)
+
+        audio_idx = (head_id[0] - 1).clamp(min=0)
+        audio_w = self.audio_lm_heads[audio_idx]
+        audio_logits = torch.mm(hidden, audio_w.t())  # [1, audio_V]
+        return audio_logits, k, v
+
+
+# ---------------------------------------------------------------------------
+# Export Helpers
+# ---------------------------------------------------------------------------
+def set_attn_implementation(model, impl: str = "sdpa"):
+    """Recursively switch all attention layers to the given implementation."""
+    for module in model.modules():
+        if hasattr(module, "attn_implementation"):
+            module.attn_implementation = impl
+
+
+def export_audio_encoder(audio_tokenizer, output_dir: Path, device: torch.device):
+    log.info("Exporting audio_encoder.onnx ...")
+    wrapper = AudioEncoderWrapper(audio_tokenizer).to(device).eval()
+    set_attn_implementation(wrapper, "sdpa")
+
+    T = 48000  # 1 second of audio
+    dummy_waveform = torch.randn(2, T, device=device, dtype=torch.float32)
+
+    # Compute the actual interleaved+padded length for the dummy input
+    ds = wrapper.downsample_rate
+    interleaved_len = T * (wrapper.number_channels if wrapper.enable_channel_interleave else 1)
+    pad_rem = interleaved_len % ds
+    if pad_rem != 0:
+        interleaved_len += ds - pad_rem
+    dummy_input_lengths = torch.tensor([interleaved_len], dtype=torch.long, device=device)
+
+    onnx_path = output_dir / "audio_encoder.onnx"
+    torch.onnx.export(
+        wrapper,
+        (dummy_waveform, dummy_input_lengths),
+        str(onnx_path),
+        opset_version=OPSET,
+        input_names=["waveform", "input_lengths"],
+        output_names=["audio_codes"],
+        dynamic_axes={
+            "waveform": {1: "waveform_length"},
+            "audio_codes": {2: "token_length"},
+        },
+    )
+    log.info("  -> %s (%.1f MB)", onnx_path, onnx_path.stat().st_size / 1e6)
+    return onnx_path
+
+
+def _patch_gpt2_for_onnx(module: nn.Module):
+    """Monkey-patch GPT2 internals for clean ONNX tracing.
+
+    Fixes two classes of ONNX export bugs:
+    1. repeat_interleave in RoPE → expand+reshape (avoids constant-folding corruption)
+    2. Python max() in _causal_attention_mask → tensor clamp (avoids frozen offset
+       that breaks KV-cache decode steps)
+    """
+    import types
+    import importlib
+
+    gpt2_mod = importlib.import_module(
+        "transformers_modules.MOSS_hyphen_TTS_hyphen_Nano_hyphen_100M.gpt2_decoder"
+    )
+
+    # --- Fix 1: RoPE repeat_interleave ---
+    def _safe_rotary_forward(self, position_ids, *, device, dtype):
+        if position_ids.ndim == 1:
+            position_ids = position_ids.unsqueeze(0)
+        pos = position_ids.to(device=device, dtype=self.inv_freq.dtype)
+        freqs = pos.unsqueeze(-1) * self.inv_freq.unsqueeze(0)  # [B, S, half]
+        c = freqs.cos()
+        s = freqs.sin()
+        half = c.shape[-1]
+        cos = c.unsqueeze(-1).expand(-1, -1, -1, 2).reshape(
+            c.shape[0], c.shape[1], half * 2
+        ).unsqueeze(2).to(dtype=dtype)
+        sin = s.unsqueeze(-1).expand(-1, -1, -1, 2).reshape(
+            s.shape[0], s.shape[1], half * 2
+        ).unsqueeze(2).to(dtype=dtype)
+        return cos, sin
+
+    def _safe_rotate_half(hidden_states):
+        even = hidden_states[..., ::2]
+        odd = hidden_states[..., 1::2]
+        neg_odd = -odd
+        interleaved = torch.stack([neg_odd, even], dim=-1)
+        return interleaved.reshape(
+            interleaved.shape[:-2] + (interleaved.shape[-2] * 2,)
+        )
+
+    # --- Fix 2: causal mask offset uses tensor ops instead of Python max() ---
+    def _safe_causal_attention_mask(self, attention_mask, query_length, key_length, device):
+        query_positions = torch.arange(query_length, device=device, dtype=torch.long)
+        key_positions = torch.arange(key_length, device=device, dtype=torch.long)
+        offset = torch.clamp(key_positions[-1:] - query_positions[-1:], min=0)
+        query_positions = query_positions + offset
+        causal = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+        causal = causal.unsqueeze(0).unsqueeze(0)
+        if attention_mask is None:
+            return causal
+        key_mask = attention_mask[:, None, None, :].to(dtype=torch.bool)
+        return causal & key_mask
+
+    for m in module.modules():
+        cls_name = type(m).__name__
+        if cls_name == "MossTTSNanoGPT2RotaryEmbedding":
+            m.forward = types.MethodType(_safe_rotary_forward, m)
+        if cls_name == "MossTTSNanoGPT2Attention":
+            m._causal_attention_mask = types.MethodType(
+                _safe_causal_attention_mask, m
+            )
+
+    gpt2_mod.rotate_half = _safe_rotate_half
+
+    return gpt2_mod
+
+
+def export_global_transformer(tts_model, output_dir: Path, device: torch.device):
+    log.info("Exporting global_transformer.onnx ...")
+    wrapper = GlobalTransformerWrapper(tts_model, nq=NQ).to(device).eval()
+    set_attn_implementation(wrapper, "eager")
+    _patch_gpt2_for_onnx(wrapper)
+
+    n_layers = wrapper.n_layers
+    T = 10
+    dummy_input_ids = torch.zeros(1, T, NQ + 1, device=device, dtype=torch.long)
+    dummy_attention_mask = torch.ones(1, T, device=device, dtype=torch.bool)
+    dummy_position_ids = torch.arange(T, device=device, dtype=torch.long).unsqueeze(0)
+
+    past_kv_flat = []
+    for _ in range(n_layers):
+        past_kv_flat.append(torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device))
+        past_kv_flat.append(torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device))
+
+    input_names = ["input_ids", "attention_mask", "position_ids"]
+    output_names = ["hidden_state"]
+    dynamic_axes = {
+        "input_ids": {1: "seq_len"},
+        "attention_mask": {1: "total_seq_len"},
+        "position_ids": {1: "seq_len"},
+        "hidden_state": {1: "seq_len"},
+    }
+    for i in range(n_layers):
+        input_names.append(f"past_key_{i}")
+        input_names.append(f"past_value_{i}")
+        output_names.append(f"present_key_{i}")
+        output_names.append(f"present_value_{i}")
+        dynamic_axes[f"past_key_{i}"] = {1: "past_seq_len"}
+        dynamic_axes[f"past_value_{i}"] = {1: "past_seq_len"}
+        dynamic_axes[f"present_key_{i}"] = {1: "total_seq_len"}
+        dynamic_axes[f"present_value_{i}"] = {1: "total_seq_len"}
+
+    args = (dummy_input_ids, dummy_attention_mask, dummy_position_ids, *past_kv_flat)
+
+    onnx_path = output_dir / "global_transformer.onnx"
+    torch.onnx.export(
+        wrapper,
+        args,
+        str(onnx_path),
+        opset_version=OPSET,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
+    log.info("  -> %s (%.1f MB)", onnx_path, onnx_path.stat().st_size / 1e6)
+    return onnx_path
+
+
+def export_local_decoder_text(tts_model, output_dir: Path, device: torch.device):
+    log.info("Exporting local_decoder_text.onnx (wte embedded, 1x/frame) ...")
+    wrapper = LocalDecoderTextWrapper(tts_model).to(device).eval()
+
+    dummy_embed = torch.randn(1, 1, HIDDEN, device=device)
+    dummy_pos = torch.zeros(1, 1, device=device, dtype=torch.long)
+    dummy_past_k = torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device)
+    dummy_past_v = torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device)
+
+    onnx_path = output_dir / "local_decoder_text.onnx"
+    torch.onnx.export(
+        wrapper,
+        (dummy_embed, dummy_pos, dummy_past_k, dummy_past_v),
+        str(onnx_path),
+        opset_version=OPSET,
+        input_names=["input_embed", "position_id", "past_key", "past_value"],
+        output_names=["candidate_logits", "candidate_embeds", "present_key", "present_value"],
+        dynamic_axes={
+            "past_key": {1: "past_seq_len"},
+            "past_value": {1: "past_seq_len"},
+            "present_key": {1: "total_seq_len"},
+            "present_value": {1: "total_seq_len"},
+        },
+    )
+    log.info("  -> %s (%.1f MB)", onnx_path, onnx_path.stat().st_size / 1e6)
+    return onnx_path
+
+
+def export_local_decoder_audio(tts_model, output_dir: Path, device: torch.device):
+    log.info("Exporting local_decoder_audio.onnx (audio heads embedded, no wte_lookup) ...")
+    wrapper = LocalDecoderAudioWrapper(tts_model, nq=NQ).to(device).eval()
+
+    dummy_embed = torch.randn(1, 1, HIDDEN, device=device)
+    dummy_pos = torch.zeros(1, 1, device=device, dtype=torch.long)
+    dummy_past_k = torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device)
+    dummy_past_v = torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device)
+    dummy_head_id = torch.tensor([1], device=device, dtype=torch.long)
+    dummy_use_ext = torch.tensor([1], device=device, dtype=torch.long)
+    dummy_prev_ch = torch.tensor([0], device=device, dtype=torch.long)
+    dummy_prev_tok = torch.tensor([0], device=device, dtype=torch.long)
+
+    onnx_path = output_dir / "local_decoder_audio.onnx"
+    torch.onnx.export(
+        wrapper,
+        (dummy_embed, dummy_pos, dummy_past_k, dummy_past_v,
+         dummy_head_id, dummy_use_ext, dummy_prev_ch, dummy_prev_tok),
+        str(onnx_path),
+        opset_version=OPSET,
+        input_names=["input_embed", "position_id", "past_key", "past_value",
+                     "head_id", "use_input_embed", "prev_audio_ch", "prev_token_id"],
+        output_names=["audio_logits", "present_key", "present_value"],
+        dynamic_axes={
+            "past_key": {1: "past_seq_len"},
+            "past_value": {1: "past_seq_len"},
+            "present_key": {1: "total_seq_len"},
+            "present_value": {1: "total_seq_len"},
+        },
+    )
+    log.info("  -> %s (%.1f MB)", onnx_path, onnx_path.stat().st_size / 1e6)
+    return onnx_path
+
+
+# ---------------------------------------------------------------------------
+# Wrapper 4: Audio Decoder (one frame per call, explicit KV-cache I/O)
+# ---------------------------------------------------------------------------
+# The audio tokenizer is a causal model whose decoder is naturally autoregressive
+# over time. We export it with the KV cache exposed as ONNX inputs/outputs so a
+# single ORT call processes one code frame in O(1) given the previous state.
+
+@dataclass
+class AttentionStateSpec:
+    decoder_module_index: int
+    layer_index: int
+    context: int
+    num_heads: int
+    head_dim: int
+
+    @property
+    def prefix(self) -> str:
+        return f"decoder_{self.decoder_module_index}_layer_{self.layer_index}"
+
+
+@dataclass
+class TransformerStateSpec:
+    decoder_module_index: int
+    num_layers: int
+
+    @property
+    def prefix(self) -> str:
+        return f"decoder_{self.decoder_module_index}"
+
+
+def _collect_state_specs(model) -> tuple[list[TransformerStateSpec], list[AttentionStateSpec]]:
+    transformer_specs: list[TransformerStateSpec] = []
+    attention_specs: list[AttentionStateSpec] = []
+    for decoder_module_index, decoder_module in enumerate(model.decoder):
+        transformer = getattr(decoder_module, "transformer", None)
+        if transformer is None:
+            continue
+        transformer_specs.append(
+            TransformerStateSpec(
+                decoder_module_index=decoder_module_index,
+                num_layers=len(transformer.layers),
+            )
+        )
+        for layer_index, layer in enumerate(transformer.layers):
+            self_attn = layer.self_attn
+            attention_specs.append(
+                AttentionStateSpec(
+                    decoder_module_index=decoder_module_index,
+                    layer_index=layer_index,
+                    context=int(self_attn.context),
+                    num_heads=int(self_attn.num_heads),
+                    head_dim=int(self_attn.embed_dim // self_attn.num_heads),
+                )
+            )
+    return transformer_specs, attention_specs
+
+
+class AudioDecoderWrapper(nn.Module):
+    """Audio-decoder wrapper for ONNX export with explicit KV-cache I/O.
+
+    Forward:
+        codes  : int64 [num_quantizers, batch=1, frames=1]
+        states : KV cache + per-stage offset tensors, in canonical order
+    Returns:
+        audio              : float32 [batch=1, channels, samples]
+        audio_lengths      : int64 [batch=1]
+        next_state_tensors : same canonical order as inputs
+    """
+
+    def __init__(self, audio_tokenizer, *, num_quantizers: int = NQ) -> None:
+        super().__init__()
+        self.quantizer = audio_tokenizer.quantizer
+        self.decoder = audio_tokenizer.decoder
+        self.number_channels = int(audio_tokenizer.number_channels)
+        self.enable_channel_interleave = bool(audio_tokenizer.enable_channel_interleave)
+        self.sampling_rate = int(audio_tokenizer.sampling_rate)
+        self.downsample_rate = int(audio_tokenizer.downsample_rate)
+        self.num_quantizers = int(num_quantizers)
+
+        self.transformer_specs, self.attention_specs = _collect_state_specs(audio_tokenizer)
+
+    def _attention_step(self, self_attn, x, *,
+                        cached_keys, cached_values, cached_positions, offset):
+        batch_size, chunk_length, _ = x.shape
+        q, k_cur, v_cur = self_attn._project_qkv(x)
+        if self_attn.rope is not None:
+            q, k_cur = self_attn.rope(q, k_cur, offset, time_before_heads=False)
+        pos_q = offset.view(-1, 1) + torch.arange(chunk_length, device=x.device, dtype=torch.long).view(1, -1)
+        k_all = torch.cat([cached_keys, k_cur], dim=2)
+        v_all = torch.cat([cached_values, v_cur], dim=2)
+        pos_k = torch.cat([cached_positions, pos_q], dim=1)
+        attn_bias = self_attn._build_streaming_sdpa_bias(pos_q, pos_k)
+        out = F.scaled_dot_product_attention(q, k_all, v_all, attn_bias, dropout_p=0.0)
+        out = out.transpose(1, 2).reshape(batch_size, chunk_length, self_attn.embed_dim)
+        out = self_attn.out_proj(out)
+
+        context = int(self_attn.context)
+        new_cached_keys = k_all[:, :, -context:, :].contiguous()
+        new_cached_values = v_all[:, :, -context:, :].contiguous()
+        new_cached_positions = pos_k[:, -context:].contiguous()
+        new_offset = offset + chunk_length
+        return out, new_cached_keys, new_cached_values, new_cached_positions, new_offset
+
+    def _projected_transformer_step(self, module, x, input_lengths, *,
+                                     transformer_offset, layer_states):
+        from modeling_moss_audio_tokenizer import create_sin_embedding
+
+        x = module.input_proj(x.transpose(1, 2))
+        transformer = module.transformer
+        if transformer.positional_embedding in {"sin", "sin_rope"}:
+            positions = torch.arange(x.shape[1], device=x.device).view(1, -1) + transformer_offset.view(-1, 1)
+            x = x + transformer.positional_scale * create_sin_embedding(
+                positions, x.shape[-1], max_period=transformer.max_period, dtype=x.dtype,
+            )
+
+        next_layer_states = []
+        for layer_index, layer in enumerate(transformer.layers):
+            cached_keys, cached_values, cached_positions, offset = layer_states[layer_index]
+            residual = x
+            normed = layer.norm1(x)
+            attn_out, new_ck, new_cv, new_cp, new_off = self._attention_step(
+                layer.self_attn, normed,
+                cached_keys=cached_keys, cached_values=cached_values,
+                cached_positions=cached_positions, offset=offset,
+            )
+            x = residual.to(attn_out) + layer.layer_scale_1(attn_out)
+            residual = x
+            normed = layer.norm2(x)
+            x = residual.to(normed) + layer.layer_scale_2(layer.ffn(normed))
+            next_layer_states.append((new_ck, new_cv, new_cp, new_off))
+
+        next_transformer_offset = transformer_offset + x.shape[1]
+        x = module.output_proj(x).transpose(1, 2)
+        return x, input_lengths, next_transformer_offset, next_layer_states
+
+    def _restore_channels(self, output_values, output_lengths):
+        if self.number_channels == 1 or not self.enable_channel_interleave:
+            return output_values.float(), output_lengths
+        output_values = (
+            output_values.squeeze(1).contiguous()
+            .view(output_values.shape[0], -1, self.number_channels)
+            .transpose(1, 2).contiguous().float()
+        )
+        output_lengths = torch.div(output_lengths, self.number_channels, rounding_mode="floor")
+        return output_values, output_lengths
+
+    def forward(self, codes: torch.Tensor, *state_inputs: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        if codes.dim() != 3:
+            raise ValueError(f"Expected codes shape [nq, 1, 1], got {tuple(codes.shape)}")
+        device = codes.device
+        batch_size = codes.shape[1]
+        if batch_size != 1:
+            raise ValueError(f"Only batch_size=1 supported, got {batch_size}")
+
+        input_lengths = torch.ones((batch_size,), device=device, dtype=torch.long)
+        x = self.quantizer.decode_codes(codes[: self.num_quantizers]).float()
+
+        attention_modules: dict[int, list[AttentionStateSpec]] = {}
+        for spec in self.attention_specs:
+            attention_modules.setdefault(spec.decoder_module_index, []).append(spec)
+
+        state_iter = iter(state_inputs)
+        output_state_tensors: list[torch.Tensor] = []
+        for decoder_module_index, decoder_module in enumerate(self.decoder):
+            if getattr(decoder_module, "transformer", None) is None:
+                x, input_lengths = decoder_module(x, input_lengths)
+                continue
+            transformer_offset = next(state_iter)
+            layer_states = []
+            for _ in attention_modules[decoder_module_index]:
+                ck = next(state_iter); cv = next(state_iter)
+                cp = next(state_iter); off = next(state_iter)
+                layer_states.append((ck, cv, cp, off))
+
+            x, input_lengths, next_off, new_layer_states = self._projected_transformer_step(
+                decoder_module, x, input_lengths,
+                transformer_offset=transformer_offset, layer_states=layer_states,
+            )
+            output_state_tensors.append(next_off)
+            for new_ck, new_cv, new_cp, new_off in new_layer_states:
+                output_state_tensors.extend([new_ck, new_cv, new_cp, new_off])
+
+        audio, audio_lengths = self._restore_channels(x, input_lengths)
+        return (audio, audio_lengths, *output_state_tensors)
+
+
+def _build_audio_decoder_io(transformer_specs, attention_specs):
+    """Return (input_names, dummy_inputs, output_names) in canonical order."""
+    input_names: list[str] = ["codes"]
+    inputs: list[torch.Tensor] = [torch.zeros((NQ, 1, 1), dtype=torch.long)]
+    output_names: list[str] = ["audio", "audio_lengths"]
+
+    grouped: dict[int, list[AttentionStateSpec]] = {}
+    for spec in attention_specs:
+        grouped.setdefault(spec.decoder_module_index, []).append(spec)
+
+    for spec in transformer_specs:
+        input_names.append(f"{spec.prefix}_transformer_offset")
+        inputs.append(torch.zeros((1,), dtype=torch.long))
+        output_names.append(f"new_{spec.prefix}_transformer_offset")
+        for attn_spec in grouped[spec.decoder_module_index]:
+            p = attn_spec.prefix
+            input_names.extend([f"{p}_cached_keys", f"{p}_cached_values",
+                                 f"{p}_cached_positions", f"{p}_offset"])
+            inputs.extend([
+                torch.zeros((1, attn_spec.num_heads, attn_spec.context, attn_spec.head_dim), dtype=torch.float32),
+                torch.zeros((1, attn_spec.num_heads, attn_spec.context, attn_spec.head_dim), dtype=torch.float32),
+                torch.full((1, attn_spec.context), -1, dtype=torch.long),
+                torch.zeros((1,), dtype=torch.long),
+            ])
+            output_names.extend([f"new_{p}_cached_keys", f"new_{p}_cached_values",
+                                  f"new_{p}_cached_positions", f"new_{p}_offset"])
+    return input_names, inputs, output_names
+
+
+def export_audio_decoder(audio_tokenizer, output_dir: Path,
+                          device: torch.device) -> dict[str, Any]:
+    """Export the audio decoder ONNX + state-spec sidecar.
+
+    Reuses the already-loaded ``audio_tokenizer`` and writes both
+    ``audio_decoder.onnx`` and ``audio_decoder_state_spec.json`` into
+    ``output_dir``.
+    """
+    log.info("Exporting audio_decoder.onnx ...")
+    wrapper = AudioDecoderWrapper(audio_tokenizer, num_quantizers=NQ).to(device).eval()
+    set_attn_implementation(wrapper, "sdpa")
+
+    input_names, inputs, output_names = _build_audio_decoder_io(
+        wrapper.transformer_specs, wrapper.attention_specs,
+    )
+    inputs = [t.to(device) for t in inputs]
+    log.info("  state spec: %d transformer stages, %d attention layers",
+             len(wrapper.transformer_specs), len(wrapper.attention_specs))
+
+    fp32_path = output_dir / "audio_decoder.onnx"
+    torch.onnx.export(
+        wrapper, tuple(inputs), str(fp32_path),
+        opset_version=OPSET,
+        input_names=input_names, output_names=output_names,
+        dynamic_axes=None, do_constant_folding=True,
+    )
+    log.info("  -> %s (%.1f MB)", fp32_path, fp32_path.stat().st_size / 1e6)
+
+    state_spec = {
+        "version": "v1",
+        "model_path_fp32": fp32_path.name,
+        "model_path_int8": "audio_decoder_int8.onnx",
+        "num_quantizers": int(wrapper.num_quantizers),
+        "batch_size": 1,
+        "frames_per_call": 1,
+        "sample_rate": int(wrapper.sampling_rate),
+        "downsample_rate": int(wrapper.downsample_rate),
+        "input_names": input_names,
+        "output_names": output_names,
+        "transformer_specs": [spec.__dict__ for spec in wrapper.transformer_specs],
+        "attention_specs": [spec.__dict__ for spec in wrapper.attention_specs],
+    }
+    spec_path = output_dir / "audio_decoder_state_spec.json"
+    spec_path.write_text(json.dumps(state_spec, ensure_ascii=False, indent=2), encoding="utf-8")
+    log.info("  -> %s", spec_path.name)
+    return state_spec
+
+
+def _verify_audio_decoder(audio_tokenizer, fp32_path: Path, state_spec: dict,
+                           device: torch.device) -> float:
+    """Smoke-test ORT vs PyTorch wrapper on a single random frame."""
+    import onnxruntime as ort
+
+    wrapper = AudioDecoderWrapper(audio_tokenizer, num_quantizers=NQ).to(device).eval()
+    set_attn_implementation(wrapper, "sdpa")
+
+    rng = np.random.default_rng(1234)
+    codebook_size = int(audio_tokenizer.quantizer.codebook_size)
+    feed = {"codes": rng.integers(0, codebook_size, size=(NQ, 1, 1), dtype=np.int64)}
+    grouped: dict[int, list[dict]] = {}
+    for s in state_spec["attention_specs"]:
+        grouped.setdefault(int(s["decoder_module_index"]), []).append(s)
+    for ts in state_spec["transformer_specs"]:
+        di = int(ts["decoder_module_index"])
+        feed[f"decoder_{di}_transformer_offset"] = np.zeros((1,), dtype=np.int64)
+        for a in grouped[di]:
+            p = f"decoder_{a['decoder_module_index']}_layer_{a['layer_index']}"
+            nh, ctx, hd = int(a["num_heads"]), int(a["context"]), int(a["head_dim"])
+            feed[f"{p}_cached_keys"] = np.zeros((1, nh, ctx, hd), dtype=np.float32)
+            feed[f"{p}_cached_values"] = np.zeros((1, nh, ctx, hd), dtype=np.float32)
+            feed[f"{p}_cached_positions"] = np.full((1, ctx), -1, dtype=np.int64)
+            feed[f"{p}_offset"] = np.zeros((1,), dtype=np.int64)
+
+    sess = ort.InferenceSession(str(fp32_path), providers=["CPUExecutionProvider"])
+    ort_audio = sess.run(None, feed)[0]
+    with torch.no_grad():
+        torch_inputs = [torch.from_numpy(feed[name]).to(device) for name in state_spec["input_names"]]
+        torch_audio = wrapper(*torch_inputs)[0].detach().cpu().numpy()
+    diff = float(np.max(np.abs(ort_audio.astype(np.float32) - torch_audio)))
+    status = "PASS" if diff < 1e-3 else "FAIL"
+    log.info("Verifying audio_decoder ... max_diff=%.6e (%s)", diff, status)
+    return diff
+
+
+def optimize_model_graphs(output_dir: Path):
+    """Apply graph-level optimizations: operator fusion, constant folding."""
+    log.info("Running graph optimization ...")
+
+    # GPT2-specific fusions for global transformer
+    from onnxruntime.transformers import optimizer
+    gt_path = str(output_dir / "global_transformer.onnx")
+    opt = optimizer.optimize_model(
+        gt_path, model_type="gpt2",
+        num_heads=NUM_HEADS, hidden_size=HIDDEN, opt_level=2,
+    )
+    stats = opt.get_fused_operator_statistics()
+    fused = {k: v for k, v in stats.items() if v > 0}
+    opt.save_model_to_file(gt_path)
+    log.info("  global_transformer fusions: %s", fused)
+
+    # Generic ORT optimization for other models (pre-bake fused ops)
+    import onnxruntime as ort
+    for name in ["local_decoder_text", "local_decoder_audio", "audio_encoder"]:
+        src = output_dir / f"{name}.onnx"
+        if not src.exists():
+            continue
+        opts = ort.SessionOptions()
+        opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+        dst = str(output_dir / f"{name}_opt.onnx")
+        opts.optimized_model_filepath = dst
+        ort.InferenceSession(str(src), opts, providers=["CPUExecutionProvider"])
+        if Path(dst).exists():
+            Path(dst).replace(src)
+            log.info("  %s optimized", name)
+
+
+def export_tokenizer_and_config(tts_model, tts_checkpoint: str, output_dir: Path, nq: int = NQ):
+    log.info("Exporting tokenizer and config ...")
+    src_dir = Path(tts_checkpoint)
+    tokenizer_src = src_dir / "tokenizer.model"
+    if tokenizer_src.exists():
+        shutil.copy2(tokenizer_src, output_dir / "tokenizer.model")
+        log.info("  -> tokenizer.model copied")
+    else:
+        log.warning("  tokenizer.model not found at %s", tokenizer_src)
+
+    cfg = tts_model.config
+    export_config = {
+        "nq": nq,
+        "n_vq": cfg.n_vq,
+        "hidden_size": cfg.gpt2_config.hidden_size,
+        "num_layers": cfg.gpt2_config.n_layer,
+        "num_heads": cfg.gpt2_config.num_attention_heads,
+        "head_dim": cfg.gpt2_config.hidden_size // cfg.gpt2_config.num_attention_heads,
+        "vocab_size": cfg.gpt2_config.vocab_size,
+        "audio_codebook_size": cfg.audio_codebook_sizes[0],
+        "audio_pad_token_id": cfg.audio_pad_token_id,
+        "pad_token_id": cfg.pad_token_id,
+        "im_start_token_id": cfg.im_start_token_id,
+        "im_end_token_id": cfg.im_end_token_id,
+        "audio_start_token_id": cfg.audio_start_token_id,
+        "audio_end_token_id": cfg.audio_end_token_id,
+        "audio_user_slot_token_id": cfg.audio_user_slot_token_id,
+        "audio_assistant_slot_token_id": cfg.audio_assistant_slot_token_id,
+        "audio_tokenizer_sample_rate": cfg.audio_tokenizer_sample_rate,
+        "audio_tokenizer_downsample_rate": 3840,
+        "audio_tokenizer_num_channels": 2,
+        "sampling_defaults": {
+            "text_temperature": 1.0,
+            "text_top_p": 1.0,
+            "text_top_k": 50,
+            "audio_temperature": 0.8,
+            "audio_top_p": 0.95,
+            "audio_top_k": 25,
+            "audio_repetition_penalty": 1.2,
+        },
+    }
+    config_path = output_dir / "config.json"
+    config_path.write_text(json.dumps(export_config, indent=2, ensure_ascii=False))
+    log.info("  -> config.json")
+
+
+# ---------------------------------------------------------------------------
+# Verification helpers
+# ---------------------------------------------------------------------------
+def verify_module(name: str, onnx_path: Path, wrapper: nn.Module,
+                  dummy_inputs: tuple, output_count: int, device: torch.device):
+    """Compare ONNX Runtime output against PyTorch output."""
+    import onnxruntime as ort
+
+    log.info("Verifying %s ...", name)
+    with torch.no_grad():
+        pt_outputs = wrapper(*dummy_inputs)
+    if not isinstance(pt_outputs, tuple):
+        pt_outputs = (pt_outputs,)
+
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    ort_inputs = {}
+    for inp, meta in zip(dummy_inputs, sess.get_inputs()):
+        val = inp.detach().cpu().numpy() if isinstance(inp, torch.Tensor) else inp
+        ort_inputs[meta.name] = val
+
+    ort_outputs = sess.run(None, ort_inputs)
+
+    max_diff = 0.0
+    for idx in range(min(len(pt_outputs), len(ort_outputs), output_count)):
+        pt_val = pt_outputs[idx].detach().cpu().float().numpy() if isinstance(pt_outputs[idx], torch.Tensor) else pt_outputs[idx]
+        ort_val = ort_outputs[idx]
+        if pt_val.shape != ort_val.shape:
+            log.warning("  output[%d] shape mismatch: PT %s vs ORT %s", idx, pt_val.shape, ort_val.shape)
+            continue
+        diff = float(np.max(np.abs(pt_val - ort_val.astype(np.float32))))
+        max_diff = max(max_diff, diff)
+
+    status = "PASS" if max_diff < 1e-3 else "FAIL"
+    log.info("  %s: max_diff=%.6f (%s)", name, max_diff, status)
+    return max_diff
+
+
+def _make_local_kv(past_T: int, device: torch.device):
+    """Create past key/value pair for local decoder verification."""
+    if past_T > 0:
+        pk = torch.randn(1, past_T, NUM_HEADS, HEAD_DIM, device=device)
+        pv = torch.randn(1, past_T, NUM_HEADS, HEAD_DIM, device=device)
+    else:
+        pk = torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device)
+        pv = pk
+    return pk, pv
+
+
+def _compute_interleaved_length(raw_len: int, ds: int, n_ch: int) -> int:
+    """Compute padded interleaved length for audio encoder verification."""
+    il = raw_len * n_ch
+    pad_r = il % ds
+    if pad_r != 0:
+        il += ds - pad_r
+    return il
+
+
+# ---------------------------------------------------------------------------
+# Quantization & manifest helpers
+# ---------------------------------------------------------------------------
+# Settings validated as smallest *and* fastest by codex review for these graphs:
+# per-tensor INT8 weights, full op coverage, no reduced range.
+QUANT_KWARGS = dict(per_channel=False, reduce_range=False)
+
+# All exportable models in the bundle (without ``_int8`` suffix).
+BUNDLE_MODELS = [
+    "audio_encoder",
+    "global_transformer",
+    "local_decoder_text",
+    "local_decoder_audio",
+    "audio_decoder",
+]
+
+
+def _quantize_models(output_dir: Path, model_names: list[str]) -> None:
+    import onnx
+    from onnxruntime.quantization import quantize_dynamic, QuantType
+
+    log.info("=" * 60)
+    log.info("Running INT8 dynamic quantization (%s) ...", QUANT_KWARGS)
+    for mname in model_names:
+        fp32 = output_dir / f"{mname}.onnx"
+        int8 = output_dir / f"{mname}_int8.onnx"
+        if not fp32.exists():
+            log.warning("  FP32 missing: %s (skip)", fp32.name)
+            continue
+        log.info("  %s.onnx", mname)
+        quantize_dynamic(
+            str(fp32), str(int8),
+            weight_type=QuantType.QInt8,
+            extra_options={"DefaultTensorType": onnx.TensorProto.FLOAT},
+            **QUANT_KWARGS,
+        )
+        a = fp32.stat().st_size / 1e6
+        b = int8.stat().st_size / 1e6
+        log.info("    %.1f MB -> %.1f MB (%.0f%% reduction)", a, b, (1 - b / a) * 100)
+
+
+def _write_manifest(output_dir: Path) -> None:
+    """Emit manifest.json describing the bundle so consumers can introspect it."""
+    entries = []
+    for f in sorted(output_dir.iterdir()):
+        if not f.is_file() or f.name == "manifest.json":
+            continue
+        entries.append({
+            "name": f.name,
+            "size_bytes": f.stat().st_size,
+            "size_mb": round(f.stat().st_size / 1e6, 3),
+        })
+    manifest = {
+        "schema": "moss-tts-nano-onnx-bundle/v2",
+        "quantization": {"weight_type": "QInt8", **QUANT_KWARGS},
+        "files": entries,
+    }
+    path = output_dir / "manifest.json"
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    log.info("Wrote manifest -> %s (%d files)", path, len(entries))
+
+
+# ---------------------------------------------------------------------------
+# Verification helpers
+# ---------------------------------------------------------------------------
+def _verify_audio_encoder(audio_tokenizer, enc_path: Path, nq: int, device: torch.device):
+    enc_wrapper = AudioEncoderWrapper(audio_tokenizer).to(device).eval()
+    set_attn_implementation(enc_wrapper, "sdpa")
+    ds = enc_wrapper.downsample_rate
+    n_ch = enc_wrapper.number_channels if enc_wrapper.enable_channel_interleave else 1
+    for test_dur in (48000, 48000 * 4, 48000 * 8):
+        il = _compute_interleaved_length(test_dur, ds, n_ch)
+        verify_module(
+            f"audio_encoder({test_dur // 48000}s)", enc_path, enc_wrapper,
+            (torch.randn(2, test_dur, device=device),
+             torch.tensor([il], dtype=torch.long, device=device)),
+            1, device,
+        )
+
+
+def _verify_global_transformer(tts_model, gt_path: Path, nq: int, device: torch.device):
+    gt_wrapper = GlobalTransformerWrapper(tts_model, nq=nq).to(device).eval()
+    set_attn_implementation(gt_wrapper, "eager")
+    _patch_gpt2_for_onnx(gt_wrapper)
+    n_layers = gt_wrapper.n_layers
+    T_test = 8
+    gt_past = tuple(torch.zeros(1, 0, NUM_HEADS, HEAD_DIM, device=device) for _ in range(2 * n_layers))
+    verify_module(
+        "global_transformer", gt_path, gt_wrapper,
+        (torch.randint(0, 100, (1, T_test, nq + 1), device=device, dtype=torch.long),
+         torch.ones(1, T_test, device=device, dtype=torch.bool),
+         torch.arange(T_test, device=device, dtype=torch.long).unsqueeze(0),
+         *gt_past),
+        1, device,
+    )
+
+
+def _verify_local_decoders(tts_model, ld_text_path: Path, ld_audio_path: Path,
+                            nq: int, device: torch.device):
+    ld_text_wrapper = LocalDecoderTextWrapper(tts_model).to(device).eval()
+    for past_T, desc in [(0, "empty KV"), (LOCAL_MAX_LEN - 1, "full KV")]:
+        pk, pv = _make_local_kv(past_T, device)
+        verify_module(
+            f"local_decoder_text({desc})", ld_text_path, ld_text_wrapper,
+            (torch.randn(1, 1, HIDDEN, device=device),
+             torch.tensor([[past_T]], device=device, dtype=torch.long),
+             pk, pv),
+            2, device,
+        )
+
+    ld_audio_wrapper = LocalDecoderAudioWrapper(tts_model, nq=nq).to(device).eval()
+    cases = [
+        (1, 1, 1, 0, 0,    "audio ch0, external embed"),
+        (2, 2, 0, 0, 500,  "audio ch1, lookup audio_embed_0[500]"),
+        (5, 8, 0, 2, 512,  "audio ch7, lookup audio_embed_2[512]"),
+    ]
+    for past_T, hid, use_ext, pch, ptok, desc in cases:
+        pk, pv = _make_local_kv(past_T, device)
+        verify_module(
+            f"local_decoder_audio({desc})", ld_audio_path, ld_audio_wrapper,
+            (torch.randn(1, 1, HIDDEN, device=device),
+             torch.tensor([[past_T]], device=device, dtype=torch.long),
+             pk, pv,
+             torch.tensor([hid], device=device, dtype=torch.long),
+             torch.tensor([use_ext], device=device, dtype=torch.long),
+             torch.tensor([pch], device=device, dtype=torch.long),
+             torch.tensor([ptok], device=device, dtype=torch.long)),
+            1, device,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export MOSS-TTS-Nano to ONNX."
+    )
+    parser.add_argument("--tts-checkpoint", default="./MOSS-TTS-Nano-100M")
+    parser.add_argument("--audio-tokenizer-checkpoint", default="./MOSS-Audio-Tokenizer-Nano")
+    parser.add_argument("--output-dir", default="./onnx_export")
+    parser.add_argument("--nq", type=int, default=NQ)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--skip-verify", action="store_true")
+    parser.add_argument("--skip-quantize", action="store_true")
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    nq = args.nq
+
+    log.info("Loading TTS model from %s ...", args.tts_checkpoint)
+    tts_model = AutoModelForCausalLM.from_pretrained(
+        args.tts_checkpoint, trust_remote_code=True
+    )
+    tts_model._set_attention_implementation("sdpa")
+    set_attn_implementation(tts_model, "sdpa")
+    tts_model.to(device=device, dtype=torch.float32).eval()
+
+    log.info("Loading Audio Tokenizer from %s ...", args.audio_tokenizer_checkpoint)
+    audio_tokenizer = AutoModel.from_pretrained(
+        args.audio_tokenizer_checkpoint, trust_remote_code=True,
+        local_files_only=True, force_download=True,
+    )
+    audio_tokenizer.set_attention_implementation("sdpa")
+    set_attn_implementation(audio_tokenizer, "sdpa")
+    audio_tokenizer.to(device=device, dtype=torch.float32).eval()
+
+    # --- FP32 ONNX export ---
+    with torch.no_grad():
+        enc_path = export_audio_encoder(audio_tokenizer, output_dir, device)
+        gt_path = export_global_transformer(tts_model, output_dir, device)
+        ld_text_path = export_local_decoder_text(tts_model, output_dir, device)
+        ld_audio_path = export_local_decoder_audio(tts_model, output_dir, device)
+        decoder_state_spec = export_audio_decoder(audio_tokenizer, output_dir, device)
+
+    export_tokenizer_and_config(tts_model, args.tts_checkpoint, output_dir, nq=nq)
+    optimize_model_graphs(output_dir)
+
+    # --- Verification (ORT vs PyTorch) ---
+    if not args.skip_verify:
+        log.info("=" * 60)
+        log.info("Running ONNX verification ...")
+        with torch.no_grad():
+            _verify_audio_encoder(audio_tokenizer, enc_path, nq, device)
+            _verify_global_transformer(tts_model, gt_path, nq, device)
+            _verify_local_decoders(tts_model, ld_text_path, ld_audio_path, nq, device)
+            _verify_audio_decoder(
+                audio_tokenizer,
+                output_dir / "audio_decoder.onnx",
+                decoder_state_spec, device,
+            )
+
+    # --- INT8 dynamic quantization (codex-validated optimal config) ---
+    if not args.skip_quantize:
+        _quantize_models(output_dir, BUNDLE_MODELS)
+
+    # --- Manifest ---
+    _write_manifest(output_dir)
+
+    log.info("=" * 60)
+    log.info("Export complete -> %s", output_dir)
+    for f in sorted(output_dir.iterdir()):
+        if f.is_file():
+            log.info("  %s (%.1f MB)", f.name, f.stat().st_size / 1e6)
+
+
+if __name__ == "__main__":
+    main()

--- a/onnx_infer.py
+++ b/onnx_infer.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""ONNX inference for MOSS-TTS-Nano.
+
+Yields waveform chunks as the autoregressive loop produces code frames,
+so the first audio chunk is available before the full sequence finishes.
+
+Usage:
+    python onnx_infer.py \
+        --onnx-dir onnx_export --precision int8 \
+        --text "你好，这是一个推理测试。" \
+        --output output.wav
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from onnx_tts_utils import (
+    SPTokenizer,
+    apply_repetition_penalty,
+    mask_unused_audio_channels,
+    normalize_audio_codes,
+    sample_top_k_top_p,
+)
+from text_normalization_pipeline import prepare_tts_request_texts
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+log = logging.getLogger(__name__)
+
+MIN_THREADS = 1
+MAX_THREADS = 8
+FIXED_INTER_OP_THREADS = 1
+DEFAULT_THREADS = 2
+DEFAULT_FRAME_SAMPLES = 3840
+DEFAULT_MAX_NEW_FRAMES = 300
+DEFAULT_FRAMES_PER_CHAR = 2.5
+DEFAULT_MIN_FRAMES = 10
+DEFAULT_MAX_FRAMES = 80
+SINGLE_PASS_TARGET_FRAMES = 30
+MIN_RMS_THRESHOLD = 0.02
+
+USER_ROLE_PREFIX = "user\n"
+USER_TEMPLATE_REFERENCE_PREFIX = "<user_inst>\n- Reference(s):\n"
+USER_TEMPLATE_AFTER_REFERENCE = (
+    "\n- Instruction:\nNone\n"
+    "- Tokens:\nNone\n"
+    "- Quality:\nNone\n"
+    "- Sound Event:\nNone\n"
+    "- Ambient Sound:\nNone\n"
+    "- Language:\nNone\n"
+    "- Text:\n"
+)
+USER_TEMPLATE_SUFFIX = "\n</user_inst>"
+ASSISTANT_TURN_PREFIX = "\n"
+ASSISTANT_ROLE_PREFIX = "assistant\n"
+
+
+class PromptBuilder:
+    """Builds model input prompts from tokenizer + config."""
+
+    def __init__(self, tokenizer: SPTokenizer, config: dict) -> None:
+        self.tokenizer = tokenizer
+        self.config = config
+        self._n_vq = int(config["n_vq"])
+        self._audio_pad = int(config["audio_pad_token_id"])
+        enc = lambda t: list(tokenizer.encode(t, add_special_tokens=False))
+        self._user_prefix = [int(config["im_start_token_id"])] + enc(USER_ROLE_PREFIX) + enc(USER_TEMPLATE_REFERENCE_PREFIX)
+        self._after_ref = enc(USER_TEMPLATE_AFTER_REFERENCE)
+        self._assistant_prefix = (
+            enc(USER_TEMPLATE_SUFFIX) + [int(config["im_end_token_id"])]
+            + enc(ASSISTANT_TURN_PREFIX) + [int(config["im_start_token_id"])]
+            + enc(ASSISTANT_ROLE_PREFIX)
+        )
+        self._none_ids = enc("None")
+
+    def _text_rows(self, ids):
+        rows = np.full((len(ids), self._n_vq + 1), self._audio_pad, dtype=np.int64)
+        for i, tok in enumerate(ids):
+            rows[i, 0] = tok
+        return rows
+
+    def _audio_prefix_rows(self, codes, slot_token_id):
+        T = codes.shape[0]
+        rows = np.full((T, self._n_vq + 1), self._audio_pad, dtype=np.int64)
+        rows[:, 0] = slot_token_id
+        rows[:, 1:] = codes
+        return rows
+
+    def _to_prompt(self, sections):
+        all_rows = np.concatenate(sections, axis=0)
+        input_ids = all_rows[np.newaxis, :, :]
+        attention_mask = np.ones((1, input_ids.shape[1]), dtype=np.bool_)
+        return input_ids, attention_mask
+
+    def build_continuation_prompt(self, text_token_ids, prompt_audio_codes=None):
+        prompt_ids = self._user_prefix + self._none_ids + self._after_ref + list(text_token_ids) + self._assistant_prefix
+        sections = [self._text_rows(prompt_ids), self._text_rows([int(self.config["audio_start_token_id"])])]
+        if prompt_audio_codes is not None:
+            sections.append(self._audio_prefix_rows(prompt_audio_codes, slot_token_id=int(self.config["audio_assistant_slot_token_id"])))
+        return self._to_prompt(sections)
+
+    def build_voice_clone_prompt(self, text_token_ids, prompt_audio_codes):
+        prefix_ids = self._user_prefix + [int(self.config["audio_start_token_id"])]
+        suffix_ids = (
+            [int(self.config["audio_end_token_id"])]
+            + self._after_ref + list(text_token_ids) + self._assistant_prefix
+            + [int(self.config["audio_start_token_id"])]
+        )
+        sections = [
+            self._text_rows(prefix_ids),
+            self._audio_prefix_rows(prompt_audio_codes, slot_token_id=int(self.config["audio_user_slot_token_id"])),
+            self._text_rows(suffix_ids),
+        ]
+        return self._to_prompt(sections)
+
+
+class AudioDecoder:
+    """ONNX audio decoder runner with managed KV-cache state.
+
+    Each call to :meth:`step` consumes one ``[nq, 1, 1]`` int64 code frame
+    and returns ``[channels, downsample_rate]`` float32 audio. Cache tensors
+    are kept inside this object so callers only pass the new frame.
+    """
+
+    def __init__(self, model_path: Path, state_spec_path: Path, sess_options) -> None:
+        import onnxruntime as ort
+        self.model_path = Path(model_path)
+        self.state_spec = json.loads(Path(state_spec_path).read_text(encoding="utf-8"))
+        self.session = ort.InferenceSession(
+            str(self.model_path),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"],
+        )
+        self.input_names = list(self.state_spec["input_names"])
+        self.output_names = list(self.state_spec["output_names"])
+        self.num_quantizers = int(self.state_spec["num_quantizers"])
+        self.sample_rate = int(self.state_spec["sample_rate"])
+        self.downsample_rate = int(self.state_spec["downsample_rate"])
+        self._zero_state = self._build_zero_state()
+        self.state: dict[str, np.ndarray] = {k: v.copy() for k, v in self._zero_state.items()}
+
+    def _build_zero_state(self) -> dict[str, np.ndarray]:
+        state: dict[str, np.ndarray] = {}
+        grouped: dict[int, list[dict]] = {}
+        for spec in self.state_spec["attention_specs"]:
+            grouped.setdefault(int(spec["decoder_module_index"]), []).append(spec)
+        for ts in self.state_spec["transformer_specs"]:
+            di = int(ts["decoder_module_index"])
+            state[f"decoder_{di}_transformer_offset"] = np.zeros((1,), dtype=np.int64)
+            for attn in grouped[di]:
+                p = f"decoder_{attn['decoder_module_index']}_layer_{attn['layer_index']}"
+                nh, ctx, hd = int(attn["num_heads"]), int(attn["context"]), int(attn["head_dim"])
+                state[f"{p}_cached_keys"] = np.zeros((1, nh, ctx, hd), dtype=np.float32)
+                state[f"{p}_cached_values"] = np.zeros((1, nh, ctx, hd), dtype=np.float32)
+                state[f"{p}_cached_positions"] = np.full((1, ctx), -1, dtype=np.int64)
+                state[f"{p}_offset"] = np.zeros((1,), dtype=np.int64)
+        return state
+
+    def reset(self) -> None:
+        """Wipe state so the decoder is ready for a new utterance."""
+        self.state = {k: v.copy() for k, v in self._zero_state.items()}
+
+    def step(self, frame_codes: np.ndarray) -> np.ndarray:
+        """Decode one frame.
+
+        Args:
+            frame_codes: int64 array shaped ``[nq, 1, 1]`` (or broadcastable).
+
+        Returns:
+            ``[channels, downsample_rate]`` float32 audio chunk.
+        """
+        codes = np.asarray(frame_codes, dtype=np.int64)
+        if codes.ndim == 1:
+            codes = codes[:, np.newaxis, np.newaxis]
+        elif codes.ndim != 3:
+            raise ValueError(f"Expected codes [nq,1,1] or [nq], got {codes.shape}")
+        feed = dict(self.state)
+        feed["codes"] = codes[: self.num_quantizers]
+        outputs = self.session.run(None, feed)
+        out_map = {name: value for name, value in zip(self.output_names, outputs)}
+        # Update state from "new_*" outputs
+        self.state = {name[4:]: out_map[name] for name in self.output_names[2:]}
+        return np.asarray(out_map["audio"], dtype=np.float32)[0]
+
+
+class OnnxTTSEngine:
+    """End-to-end ONNX TTS engine.
+
+    Loads ``audio_encoder``, ``global_transformer``, ``local_decoder_text``,
+    ``local_decoder_audio`` for autoregressive code generation, and
+    ``audio_decoder`` (+ state spec) for waveform decoding.
+    """
+
+    def __init__(
+        self,
+        onnx_dir: str,
+        precision: str = "auto",
+        threads: int = DEFAULT_THREADS,
+    ):
+        import onnxruntime as ort
+
+        onnx_dir_path = Path(onnx_dir).expanduser().resolve()
+        suffix, resolved_precision = self._resolve_precision(onnx_dir_path, precision)
+
+        self.onnx_dir = str(onnx_dir_path)
+        self.precision = resolved_precision
+        self.threads = int(threads)
+
+        sess_options = ort.SessionOptions()
+        sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        sess_options.intra_op_num_threads = self.threads
+        sess_options.inter_op_num_threads = FIXED_INTER_OP_THREADS
+        sess_options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+
+        def load_session(name, allow_fp32_fallback=False):
+            path = onnx_dir_path / f"{name}{suffix}.onnx"
+            if not path.is_file():
+                raise FileNotFoundError(f"Missing: {path}")
+            log.info("  Loading %s (%.1f MB)", path.name, path.stat().st_size / 1e6)
+            try:
+                return ort.InferenceSession(str(path), sess_options=sess_options, providers=["CPUExecutionProvider"])
+            except Exception as e:
+                if allow_fp32_fallback and suffix:
+                    fp32_path = onnx_dir_path / f"{name}.onnx"
+                    if fp32_path.is_file():
+                        log.warning("  INT8 %s failed (%s), falling back to FP32", name, e)
+                        return ort.InferenceSession(str(fp32_path), sess_options=sess_options, providers=["CPUExecutionProvider"])
+                raise
+
+        log.info("Loading ONNX sessions from %s (precision=%s) ...", onnx_dir_path, resolved_precision)
+        self.audio_encoder = load_session("audio_encoder", allow_fp32_fallback=True)
+        self.global_transformer = load_session("global_transformer")
+        self.local_decoder_text = load_session("local_decoder_text")
+        self.local_decoder_audio = load_session("local_decoder_audio")
+
+        base = "audio_decoder"
+        int8_path = onnx_dir_path / f"{base}_int8.onnx"
+        fp32_path = onnx_dir_path / f"{base}.onnx"
+        spec_path = onnx_dir_path / f"{base}_state_spec.json"
+        if not spec_path.is_file():
+            raise FileNotFoundError(
+                f"Audio decoder state spec missing: {spec_path}. "
+                "Run export_onnx.py to produce the bundle."
+            )
+        preferred = int8_path if (resolved_precision == "int8" and int8_path.is_file()) else fp32_path
+        if not preferred.is_file():
+            preferred = fp32_path if fp32_path.is_file() else int8_path
+        if not preferred.is_file():
+            raise FileNotFoundError(f"No audio decoder ONNX in {onnx_dir_path}")
+        log.info("  Loading %s (%.1f MB)", preferred.name, preferred.stat().st_size / 1e6)
+        self.audio_decoder = AudioDecoder(preferred, spec_path, sess_options)
+
+        self.config = json.loads((onnx_dir_path / "config.json").read_text(encoding="utf-8"))
+        self.tokenizer = SPTokenizer(str(onnx_dir_path / "tokenizer.model"))
+        self.prompt_builder = PromptBuilder(self.tokenizer, self.config)
+
+        self.nq = int(self.config.get("nq", self.config.get("n_vq", 16)))
+        self.hidden_size = int(self.config["hidden_size"])
+        self.num_layers = int(self.config["num_layers"])
+        self.num_heads = int(self.config["num_heads"])
+        self.head_dim = int(self.config["head_dim"])
+        self._gt_kv_names = [inp.name for inp in self.global_transformer.get_inputs() if inp.name.startswith("past_")]
+        self._empty_gt_kv = np.zeros((1, 0, self.num_heads, self.head_dim), dtype=np.float32)
+
+        log.info("Engine ready (nq=%d, hidden=%d)", self.nq, self.hidden_size)
+
+    @staticmethod
+    def _resolve_precision(onnx_dir_path, precision):
+        # The accumulating audio_decoder is intentionally excluded: it is no
+        # longer required by the engine and the bundle may omit it.
+        base_names = ["audio_encoder", "global_transformer",
+                      "local_decoder_text", "local_decoder_audio"]
+
+        def has_all(suffix):
+            return all((onnx_dir_path / f"{name}{suffix}.onnx").is_file() for name in base_names)
+
+        if precision == "int8":
+            if not has_all("_int8"):
+                raise FileNotFoundError(f"INT8 models incomplete in {onnx_dir_path}")
+            return "_int8", "int8"
+        if precision == "fp32":
+            if not has_all(""):
+                raise FileNotFoundError(f"FP32 models incomplete in {onnx_dir_path}")
+            return "", "fp32"
+        if has_all("_int8"):
+            return "_int8", "int8"
+        if has_all(""):
+            return "", "fp32"
+        raise FileNotFoundError(f"No complete ONNX export in {onnx_dir_path}")
+
+    def encode_audio(self, waveform):
+        ds = int(self.config.get("audio_tokenizer_downsample_rate", DEFAULT_FRAME_SAMPLES))
+        n_ch = int(self.config.get("audio_tokenizer_num_channels", 2))
+        raw_len = int(waveform.shape[-1])
+        input_length = raw_len * n_ch
+        pad_rem = input_length % ds
+        if pad_rem != 0:
+            input_length += ds - pad_rem
+        result = self.audio_encoder.run(None, {
+            "waveform": np.asarray(waveform, dtype=np.float32),
+            "input_lengths": np.array([input_length], dtype=np.int64),
+        })
+        return result[0]
+
+    def _encode_prompt_audio(self, prompt_audio_path):
+        cfg = self.config
+        waveform, sample_rate = sf.read(prompt_audio_path, dtype="float32", always_2d=True)
+        waveform = waveform.T
+        target_sr = int(cfg["audio_tokenizer_sample_rate"])
+        target_ch = int(cfg["audio_tokenizer_num_channels"])
+        if sample_rate != target_sr:
+            import resampy
+            waveform = resampy.resample(waveform, sample_rate, target_sr, axis=-1)
+        if waveform.shape[0] < target_ch:
+            waveform = np.repeat(waveform, target_ch, axis=0)[:target_ch]
+        elif waveform.shape[0] > target_ch:
+            waveform = waveform[:target_ch]
+        audio_codes = self.encode_audio(waveform)
+        nq = self.nq
+        audio_codes = normalize_audio_codes(audio_codes, nq)
+        audio_codes = mask_unused_audio_channels(audio_codes, nq, int(cfg["audio_pad_token_id"]))
+        log.info("Encoded prompt audio: %s", audio_codes.shape)
+        return audio_codes
+
+    def _run_global_transformer(self, current_ids, mask, position_ids, past_kv):
+        feed = {
+            "input_ids": np.asarray(current_ids, dtype=np.int64),
+            "attention_mask": np.asarray(mask, dtype=np.bool_),
+            "position_ids": np.asarray(position_ids, dtype=np.int64),
+        }
+        if past_kv is None:
+            for name in self._gt_kv_names:
+                feed[name] = self._empty_gt_kv
+        else:
+            for name, arr in zip(self._gt_kv_names, past_kv):
+                feed[name] = arr
+        outputs = self.global_transformer.run(None, feed)
+        hidden = outputs[0]
+        new_kv = outputs[1:]
+        return hidden, new_kv
+
+    def _run_local_decoder_text(self, hidden, pos_id, local_key, local_value):
+        outputs = self.local_decoder_text.run(None, {
+            "input_embed": np.asarray(hidden, dtype=np.float32),
+            "position_id": np.asarray(pos_id, dtype=np.int64),
+            "past_key": np.asarray(local_key, dtype=np.float32),
+            "past_value": np.asarray(local_value, dtype=np.float32),
+        })
+        return outputs[0], outputs[1], outputs[2], outputs[3]
+
+    def _run_local_decoder_audio(self, embed, pos_id, local_key, local_value,
+                                  head_id, use_external, prev_channel, prev_token):
+        outputs = self.local_decoder_audio.run(None, {
+            "input_embed": np.asarray(embed, dtype=np.float32),
+            "position_id": np.asarray(pos_id, dtype=np.int64),
+            "past_key": np.asarray(local_key, dtype=np.float32),
+            "past_value": np.asarray(local_value, dtype=np.float32),
+            "head_id": np.asarray(head_id, dtype=np.int64),
+            "use_input_embed": np.asarray(use_external, dtype=np.int64),
+            "prev_audio_ch": np.asarray(prev_channel, dtype=np.int64),
+            "prev_token_id": np.asarray(prev_token, dtype=np.int64),
+        })
+        return outputs[0], outputs[1], outputs[2]
+
+    def _autoregressive_generate(
+        self,
+        input_ids: np.ndarray,
+        max_new_frames: int,
+        do_sample: bool,
+        text_temperature: float,
+        text_top_p: float,
+        text_top_k: int,
+        audio_temperature: float,
+        audio_top_p: float,
+        audio_top_k: int,
+        audio_repetition_penalty: float,
+    ) -> np.ndarray:
+        """Generate audio token frames. Returns history_buf[:n_generated]."""
+        cfg = self.config
+        nq = self.nq
+        audio_pad = int(cfg["audio_pad_token_id"])
+        audio_slot = int(cfg["audio_assistant_slot_token_id"])
+        empty_local_kv = np.zeros((1, 0, self.num_heads, self.head_dim), dtype=np.float32)
+
+        past_kv = None
+        current_ids = input_ids
+        seq_len = int(current_ids.shape[1])
+        position_ids = np.arange(seq_len, dtype=np.int64)[np.newaxis, :]
+        max_total_len = seq_len + max_new_frames
+        mask_buf = np.ones((1, max_total_len), dtype=np.bool_)
+        mask_len = seq_len
+
+        history_buf = np.zeros((max_new_frames, nq), dtype=np.int64)
+        n_generated = 0
+
+        local_pos_ids = [np.array([[i]], dtype=np.int64) for i in range(nq + 1)]
+        head_ids = [np.array([i], dtype=np.int64) for i in range(nq + 1)]
+        next_row = np.full((1, 1, nq + 1), audio_pad, dtype=np.int64)
+
+        use_ext = np.array([1], dtype=np.int64)
+        use_lookup = np.array([0], dtype=np.int64)
+        dummy_embed = np.zeros((1, 1, self.hidden_size), dtype=np.float32)
+        dummy_ch = np.array([0], dtype=np.int64)
+        dummy_tok = np.array([0], dtype=np.int64)
+
+        started = time.time()
+        for step in range(max_new_frames):
+            hidden, new_kv = self._run_global_transformer(
+                current_ids, mask_buf[:, :mask_len], position_ids, past_kv,
+            )
+
+            local_key = empty_local_kv.copy()
+            local_value = empty_local_kv.copy()
+            candidate_logits, candidate_embeds, local_key, local_value = self._run_local_decoder_text(
+                hidden, local_pos_ids[0], local_key, local_value,
+            )
+            candidate_logits = candidate_logits[0]
+            if do_sample:
+                sampled_idx = sample_top_k_top_p(candidate_logits, text_temperature, text_top_k, text_top_p)
+            else:
+                sampled_idx = int(np.argmax(candidate_logits))
+            if sampled_idx == 1:
+                break
+
+            text_embed = candidate_embeds[0:1][np.newaxis, :, :]
+            frame_tokens = np.full(nq, audio_pad, dtype=np.int64)
+            audio_history = history_buf[:n_generated] if n_generated > 0 else None
+
+            for ch in range(nq):
+                if ch == 0:
+                    ch_logits, local_key, local_value = self._run_local_decoder_audio(
+                        text_embed, local_pos_ids[ch + 1], local_key, local_value,
+                        head_ids[ch + 1], use_ext, dummy_ch, dummy_tok,
+                    )
+                else:
+                    ch_logits, local_key, local_value = self._run_local_decoder_audio(
+                        dummy_embed, local_pos_ids[ch + 1], local_key, local_value,
+                        head_ids[ch + 1], use_lookup, np.array([ch - 1], dtype=np.int64),
+                        np.array([frame_tokens[ch - 1]], dtype=np.int64),
+                    )
+                ch_logits = ch_logits[0]
+                previous_ids = audio_history[:, ch] if audio_history is not None else None
+                ch_logits = apply_repetition_penalty(ch_logits, previous_ids, audio_repetition_penalty)
+                if do_sample:
+                    tok = sample_top_k_top_p(ch_logits, audio_temperature, audio_top_k, audio_top_p)
+                else:
+                    tok = int(np.argmax(ch_logits))
+                frame_tokens[ch] = tok
+
+            history_buf[n_generated] = frame_tokens
+            n_generated += 1
+
+            next_row[0, 0, 0] = audio_slot
+            next_row[0, 0, 1:nq + 1] = frame_tokens
+            past_kv = new_kv
+            current_ids = next_row
+            position_ids = np.array([[mask_len]], dtype=np.int64)
+            mask_len += 1
+
+            if (step + 1) % 50 == 0:
+                elapsed = time.time() - started
+                log.info("  step %d/%d (%.1f frames/sec)", step + 1, max_new_frames, (step + 1) / elapsed)
+
+        elapsed = time.time() - started
+        fps = n_generated / elapsed if elapsed > 0 else 0
+        log.info("Generation done: %d frames in %.1fs (%.1f frames/sec)", n_generated, elapsed, fps)
+        return history_buf[:n_generated]
+
+    def generate(
+        self,
+        text: str,
+        prompt_audio_path: Optional[str] = None,
+        mode: str = "continuation",
+        max_new_frames: int = DEFAULT_MAX_NEW_FRAMES,
+        do_sample: bool = True,
+        text_temperature: float = 1.0,
+        text_top_p: float = 1.0,
+        text_top_k: int = 50,
+        audio_temperature: float = 0.8,
+        audio_top_p: float = 0.95,
+        audio_top_k: int = 25,
+        audio_repetition_penalty: float = 1.2,
+    ):
+        """Generate audio for ``text``, yielding one chunk per code frame.
+
+        Yields ``(waveform_chunk, frame_index, is_final)``. First-chunk
+        latency is ~60-90 ms on CPU INT8 (one AR step + one decoder call).
+        """
+        cfg = self.config
+        nq = self.nq
+        audio_pad = int(cfg["audio_pad_token_id"])
+        audio_slot = int(cfg["audio_assistant_slot_token_id"])
+        text_ids = self.tokenizer.encode(text)
+
+        prompt_audio_codes = self._encode_prompt_audio(prompt_audio_path) if prompt_audio_path else None
+        resolved_mode = str(mode or "continuation").strip().lower() or "continuation"
+        if prompt_audio_codes is not None and resolved_mode == "continuation":
+            resolved_mode = "voice_clone"
+        if resolved_mode == "voice_clone" and prompt_audio_codes is None:
+            raise ValueError("voice_clone mode requires --prompt-audio-path.")
+
+        if resolved_mode == "voice_clone":
+            input_ids, _ = self.prompt_builder.build_voice_clone_prompt(text_ids, prompt_audio_codes)
+        else:
+            input_ids, _ = self.prompt_builder.build_continuation_prompt(text_ids, prompt_audio_codes)
+
+        log.info("Inference mode: %s", resolved_mode)
+        log.info("Prompt shape: input_ids=%s", input_ids.shape)
+
+        # --- Setup KV-cached autoregressive loop ---
+        empty_local_kv = np.zeros((1, 0, self.num_heads, self.head_dim), dtype=np.float32)
+        past_kv = None
+        current_ids = input_ids
+        seq_len = int(current_ids.shape[1])
+        position_ids = np.arange(seq_len, dtype=np.int64)[np.newaxis, :]
+        max_total_len = seq_len + max_new_frames
+        mask_buf = np.ones((1, max_total_len), dtype=np.bool_)
+        mask_len = seq_len
+
+        history_buf = np.zeros((max_new_frames, nq), dtype=np.int64)
+        n_generated = 0
+
+        local_pos_ids = [np.array([[i]], dtype=np.int64) for i in range(nq + 1)]
+        head_ids = [np.array([i], dtype=np.int64) for i in range(nq + 1)]
+        next_row = np.full((1, 1, nq + 1), audio_pad, dtype=np.int64)
+        use_ext = np.array([1], dtype=np.int64)
+        use_lookup = np.array([0], dtype=np.int64)
+        dummy_embed = np.zeros((1, 1, self.hidden_size), dtype=np.float32)
+        dummy_ch = np.array([0], dtype=np.int64)
+        dummy_tok = np.array([0], dtype=np.int64)
+
+        self.audio_decoder.reset()
+        gen_started = time.time()
+
+        for step in range(max_new_frames):
+            hidden, new_kv = self._run_global_transformer(
+                current_ids, mask_buf[:, :mask_len], position_ids, past_kv,
+            )
+
+            local_key = empty_local_kv.copy()
+            local_value = empty_local_kv.copy()
+            cand_logits, cand_embeds, local_key, local_value = self._run_local_decoder_text(
+                hidden, local_pos_ids[0], local_key, local_value,
+            )
+            cand_logits = cand_logits[0]
+            if do_sample:
+                sampled_idx = sample_top_k_top_p(cand_logits, text_temperature, text_top_k, text_top_p)
+            else:
+                sampled_idx = int(np.argmax(cand_logits))
+
+            # EOS: flush remaining codes and exit
+            if sampled_idx == 1:
+                log.info("EOS at step %d (n_generated=%d)", step, n_generated)
+                break
+
+            text_embed = cand_embeds[0:1][np.newaxis, :, :]
+            frame_tokens = np.full(nq, audio_pad, dtype=np.int64)
+            audio_history = history_buf[:n_generated] if n_generated > 0 else None
+
+            for ch in range(nq):
+                if ch == 0:
+                    ch_logits, local_key, local_value = self._run_local_decoder_audio(
+                        text_embed, local_pos_ids[ch + 1], local_key, local_value,
+                        head_ids[ch + 1], use_ext, dummy_ch, dummy_tok,
+                    )
+                else:
+                    ch_logits, local_key, local_value = self._run_local_decoder_audio(
+                        dummy_embed, local_pos_ids[ch + 1], local_key, local_value,
+                        head_ids[ch + 1], use_lookup, np.array([ch - 1], dtype=np.int64),
+                        np.array([frame_tokens[ch - 1]], dtype=np.int64),
+                    )
+                ch_logits = ch_logits[0]
+                previous_ids = audio_history[:, ch] if audio_history is not None else None
+                ch_logits = apply_repetition_penalty(ch_logits, previous_ids, audio_repetition_penalty)
+                if do_sample:
+                    tok = sample_top_k_top_p(ch_logits, audio_temperature, audio_top_k, audio_top_p)
+                else:
+                    tok = int(np.argmax(ch_logits))
+                frame_tokens[ch] = tok
+
+            history_buf[n_generated] = frame_tokens
+            n_generated += 1
+
+            next_row[0, 0, 0] = audio_slot
+            next_row[0, 0, 1:nq + 1] = frame_tokens
+            past_kv = new_kv
+            current_ids = next_row
+            position_ids = np.array([[mask_len]], dtype=np.int64)
+            mask_len += 1
+
+            chunk = self.audio_decoder.step(frame_tokens)
+            if chunk.shape[-1] > 0:
+                yield chunk, n_generated - 1, False
+
+        elapsed = time.time() - gen_started
+        fps = n_generated / elapsed if elapsed > 0 else 0
+        log.info("Done: %d frames in %.2fs (%.1f frames/sec)", n_generated, elapsed, fps)
+        yield np.zeros((2, 0), dtype=np.float32), n_generated, True
+
+
+def generate_to_file(
+    engine: OnnxTTSEngine,
+    text: str,      
+    output_path: str,
+    prompt_audio_path: Optional[str] = None,
+    mode: str = "continuation",
+    max_new_frames: int = DEFAULT_MAX_NEW_FRAMES,
+):
+    """Run generation and save concatenated audio to file."""
+    sample_rate = int(engine.config["audio_tokenizer_sample_rate"])
+    audio_chunks = []
+    first_audio_time = None
+    total_code_frames = 0
+    started = time.time()
+
+    for chunk, frame_idx, is_final in engine.generate(
+        text=text,
+        prompt_audio_path=prompt_audio_path,
+        mode=mode,
+        max_new_frames=max_new_frames,
+    ):
+        if is_final:
+            total_code_frames = frame_idx
+            break
+        if first_audio_time is None:
+            first_audio_time = time.time()
+            log.info("First audio chunk at %.3fs", first_audio_time - started)
+        audio_chunks.append(chunk)
+
+    if not audio_chunks:
+        log.warning("No audio generated!")
+        return None
+
+    full_waveform = np.concatenate(audio_chunks, axis=-1)
+    audio_seconds = full_waveform.shape[-1] / sample_rate
+    wall_seconds = time.time() - started
+    first_chunk_latency = (first_audio_time - started) if first_audio_time else 0
+    resolved_mode = "voice_clone" if prompt_audio_path else "continuation"
+
+    out_path = Path(output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(out_path), full_waveform.T, sample_rate)
+
+    rtf = wall_seconds / audio_seconds if audio_seconds > 0 else float("inf")
+    log.info("Wrote %s (%.2fs audio, %d code frames, %d chunks)", out_path, audio_seconds, total_code_frames, len(audio_chunks))
+    log.info("RTF=%.3f | wall=%.2fs | first_chunk=%.3fs", rtf, wall_seconds, first_chunk_latency)
+
+    return {
+        "audio_path": str(out_path.resolve()),
+        "sample_rate": sample_rate,
+        "total_frames": total_code_frames,
+        "decode_chunks": len(audio_chunks),
+        "audio_seconds": audio_seconds,
+        "wall_seconds": wall_seconds,
+        "first_chunk_latency": first_chunk_latency,
+        "rtf": rtf,
+        "mode": resolved_mode,
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="ONNX inference for MOSS-TTS-Nano")
+    parser.add_argument("--onnx-dir", default="onnx_export", help="ONNX model directory")
+    parser.add_argument("--precision", default="int8", choices=["auto", "int8", "fp32"])
+    parser.add_argument("--output", required=True, help="Output wav path")
+    parser.add_argument("--threads", type=int, default=DEFAULT_THREADS)
+    parser.add_argument("--prompt-audio-path", default=None, help="Reference audio for voice cloning")
+    text_group = parser.add_mutually_exclusive_group(required=True)
+    text_group.add_argument("--text", help="Text to synthesize")
+    text_group.add_argument("--text-file", help="UTF-8 text file")
+    parser.add_argument("--max-frames", type=int, default=DEFAULT_MAX_NEW_FRAMES)
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
+    args = parse_args()
+    text = args.text if args.text else Path(args.text_file).read_text(encoding="utf-8")
+
+    prepared = prepare_tts_request_texts(
+        text=text,
+        prompt_text="",
+        voice="",
+        enable_wetext=False,
+        enable_normalize_tts_text=True,
+        text_normalizer_manager=None,
+    )
+    normalized_text = str(prepared["text"]).strip() or text
+    log.info("Text normalization: method=%s chars=%d",
+             prepared.get("normalization_method", "unknown"), len(normalized_text))
+
+    engine = OnnxTTSEngine(
+        onnx_dir=args.onnx_dir,
+        precision=args.precision,
+        threads=args.threads,
+    )
+
+    mode = "voice_clone" if args.prompt_audio_path else "continuation"
+    summary = generate_to_file(
+        engine=engine,
+        text=normalized_text,
+        output_path=args.output,
+        prompt_audio_path=args.prompt_audio_path,
+        mode=mode,
+        max_new_frames=args.max_frames,
+    )
+
+    if summary:
+        print("\nConfig:")
+        print(f"  onnx_dir: {Path(args.onnx_dir).resolve()}")
+        print(f"  precision: {engine.precision}")
+        print(f"  threads: {engine.threads}")
+        print("Result:")
+        print(f"  output: {summary['audio_path']}")
+        print(f"  mode: {summary['mode']}")
+        print(f"  code_frames: {summary['total_frames']}")
+        print(f"  decode_chunks: {summary['decode_chunks']}")
+        print(f"  audio_seconds: {summary['audio_seconds']:.2f}")
+        print(f"  wall_seconds: {summary['wall_seconds']:.2f}")
+        print(f"  first_chunk_latency: {summary['first_chunk_latency']:.3f}")
+        print(f"  rtf: {summary['rtf']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/onnx_tts_utils.py
+++ b/onnx_tts_utils.py
@@ -1,0 +1,125 @@
+"""Shared utilities for ONNX-based MOSS-TTS-Nano inference.
+
+Contains sampling helpers, audio code normalization, and a lightweight
+SentencePiece tokenizer wrapper — all independent of the inference engine.
+"""
+from __future__ import annotations
+
+import numpy as np
+import sentencepiece as spm
+
+
+# ---------------------------------------------------------------------------
+# SentencePiece tokenizer wrapper
+# ---------------------------------------------------------------------------
+class SPTokenizer:
+    """Thin wrapper around SentencePiece for encode/decode."""
+
+    def __init__(self, model_path: str) -> None:
+        self.model_path = str(model_path)
+        self.processor = spm.SentencePieceProcessor()
+        self.processor.Load(self.model_path)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return list(self.processor.encode(str(text), out_type=int))
+
+    def decode(self, token_ids) -> str:
+        return str(self.processor.decode(list(token_ids)))
+
+
+# ---------------------------------------------------------------------------
+# Sampling utilities
+# ---------------------------------------------------------------------------
+def softmax_numpy(scores: np.ndarray) -> np.ndarray:
+    exp_scores = np.exp(scores - np.max(scores))
+    return exp_scores / exp_scores.sum()
+
+
+def sample_top_k_top_p(logits: np.ndarray, temperature: float, top_k: int, top_p: float) -> int:
+    if temperature <= 0:
+        return int(np.argmax(logits))
+
+    scores = logits / temperature
+
+    if top_k > 0:
+        top_k = min(top_k, len(scores))
+        kth = np.partition(scores, -top_k)[-top_k]
+        scores[scores < kth] = -np.inf
+
+    if 0.0 < top_p < 1.0:
+        sorted_idx = np.argsort(scores)[::-1]
+        sorted_scores = scores[sorted_idx]
+        probs_sorted = softmax_numpy(sorted_scores)
+        cumsum = np.cumsum(probs_sorted)
+        cutoff = np.searchsorted(cumsum, top_p) + 1
+        sorted_scores[cutoff:] = -np.inf
+        scores = np.full_like(scores, -np.inf)
+        scores[sorted_idx] = sorted_scores
+
+    probs = softmax_numpy(scores)
+    return int(np.random.choice(np.arange(probs.size), p=probs))
+
+
+def apply_repetition_penalty(logits: np.ndarray, previous_token_ids, repetition_penalty: float) -> np.ndarray:
+    if repetition_penalty <= 0:
+        raise ValueError("repetition_penalty must be positive")
+    if repetition_penalty == 1.0 or previous_token_ids is None or len(previous_token_ids) == 0:
+        return logits
+
+    scores = logits.copy()
+    unique_ids = np.unique(previous_token_ids)
+    unique_ids = unique_ids[(unique_ids >= 0) & (unique_ids < len(scores))]
+    for token_id in unique_ids:
+        if scores[token_id] < 0:
+            scores[token_id] *= repetition_penalty
+        else:
+            scores[token_id] /= repetition_penalty
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Audio code normalization
+# ---------------------------------------------------------------------------
+def normalize_audio_codes(audio_codes, n_vq: int) -> np.ndarray:
+    """Normalize audio codes to shape [T, n_vq] regardless of input layout."""
+    tensor = np.asarray(audio_codes)
+    if tensor.ndim == 1:
+        tensor = tensor[:, np.newaxis]
+
+    if tensor.ndim == 3:
+        if tensor.shape[1] == 1 and tensor.shape[0] >= n_vq:
+            tensor = tensor[:n_vq, 0, :].transpose(1, 0)
+        elif tensor.shape[0] == 1:
+            tensor = tensor[0]
+        elif tensor.shape[1] == n_vq:
+            tensor = tensor.transpose(0, 2, 1)[0]
+        elif tensor.shape[-1] == n_vq:
+            tensor = tensor[0]
+        else:
+            raise ValueError(f"Unable to normalize audio codes with shape {tuple(tensor.shape)}")
+
+    if tensor.ndim != 2:
+        raise ValueError(f"Expected audio codes with 2 dims after normalization, got {tuple(tensor.shape)}")
+
+    if tensor.shape[-1] != n_vq and tensor.shape[0] == n_vq:
+        tensor = tensor.transpose(1, 0)
+    elif tensor.shape[-1] != n_vq and tensor.shape[0] > n_vq:
+        tensor = tensor[:n_vq].transpose(1, 0)
+    elif tensor.shape[-1] > n_vq:
+        tensor = tensor[:, :n_vq]
+
+    if tensor.shape[-1] != n_vq:
+        raise ValueError(f"Expected normalized audio codes with trailing dim {n_vq}, got {tuple(tensor.shape)}")
+    return tensor.astype(np.int64, copy=False)
+
+
+def mask_unused_audio_channels(audio_codes: np.ndarray, nq: int, audio_pad_token_id: int) -> np.ndarray:
+    """Zero-out audio channels beyond nq with the pad token."""
+    tensor = np.asarray(audio_codes, dtype=np.int64)
+    if tensor.ndim != 2:
+        raise ValueError(f"Expected prompt audio codes with shape [T, n_vq], got {tuple(tensor.shape)}")
+    if nq < tensor.shape[-1]:
+        tensor = tensor.copy()
+        tensor[:, nq:] = int(audio_pad_token_id)
+    return tensor


### PR DESCRIPTION
Adds an end-to-end ONNX deployment path so MOSS-TTS-Nano can run on CPU via ONNX Runtime alone, without PyTorch/Transformers at inference time. The model's existing PyTorch entry points (infer.py, app.py, moss-tts-nano CLI) are left completely untouched.

New files:
- export_onnx.py    : exports five ONNX graphs (audio_encoder,
                      global_transformer, local_decoder_text,
                      local_decoder_audio, audio_decoder) plus tokenizer,
                      config and manifest. Includes ORT graph-fusion
                      and INT8 dynamic quantization (per_channel=False,
                      reduce_range=False) validated as the smallest +
                      fastest setting on these graphs.
- onnx_infer.py     : OnnxTTSEngine + CLI. Streams one audio chunk
                      per generated code frame using a KV-cached
                      audio decoder; ~80ms first-chunk latency on a
                      4-core CPU laptop (INT8). Supports voice cloning
                      via --prompt-audio-path.
- onnx_tts_utils.py : SentencePiece + sampling utilities shared
                      between export-time and inference-time code.
- README_ONNX.md    : English design notes, performance numbers,
                      architecture rationale.
- README_ONNX_zh.md : Chinese mirror, matching the existing
                      README.md / README_zh.md convention.

Existing files touched:
- README.md / README_zh.md : add a "ONNX deployment" subsection under Quickstart, linking to the detailed docs.
- .gitignore               : exclude local model checkpoints, the
                             onnx_export/ bundle, runtime outputs.

Bundle size: ~640 MB FP32 / ~165 MB INT8 across the five graphs.

Made-with: Cursor