### PR TITLE
docs: add pointer to vLLM Omni for MOSS-TTS-Nano serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ moss-tts-nano serve \
 
 This command forwards to `app.py`, keeps the model loaded in memory, and serves the local browser demo plus HTTP generation endpoints.
 
+For server deployment with paged KV cache, streaming, and an OpenAI-compatible `/v1/audio/speech` endpoint, please read the [vLLM-Omni MOSS-TTS-Nano README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/moss_tts_nano/README.md).
+
 ### Finetuning
 
 Finetuning tutorials are already provided.

--- a/README_zh.md
+++ b/README_zh.md
@@ -196,6 +196,8 @@ moss-tts-nano serve \
 
 此命令转发到 `app.py`，将模型保持在内存中加载，并为本地浏览器演示和 HTTP 生成端点提供服务。
 
+如需以分页 KV 缓存、流式推理以及 OpenAI 兼容 `/v1/audio/speech` 接口部署服务，请参考 [vLLM-Omni MOSS-TTS-Nano README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/moss_tts_nano/README.md)。
+
 ### 微调
 
 微调教程已经提供。


### PR DESCRIPTION
## Summary

Hi MOSS team, we're from the vLLM Omni team (https://github.com/vllm-project/vllm-omni).

MOSS-TTS-Nano is a great tiny TTS model and we've added support for `OpenMOSS-Team/MOSS-TTS-Nano` in vLLM Omni: voice cloning from reference audio, streaming via the OpenAI-compatible `/v1/audio/speech` endpoint, and a Gradio demo.

This PR adds a small pointer to our docs in the existing `moss-tts-nano serve` section. Documentation only.

Thanks for the open release.

cc @hsliuustc0106

## Changes
- `README.md`: append vLLM Omni pointer in the `moss-tts-nano serve` section
- `README_zh.md`: same change in Chinese

## Test plan
- [ ] Link resolves to the vllm-omni MOSS-TTS-Nano README on `main`
- [ ] Both README files updated; no markdown lint regressions